### PR TITLE
feat: add profile get/push to endpoints

### DIFF
--- a/src/api/data/MemberData.ts
+++ b/src/api/data/MemberData.ts
@@ -1,5 +1,5 @@
 import { NewsletterStatus } from "@core/providers/newsletter";
-import { ContributionPeriod, ContributionType } from "@core/utils";
+import { ContributionPeriod } from "@core/utils";
 import Address from "@models/Address";
 import { PermissionType } from "@models/MemberPermission";
 import { Type } from "class-transformer";
@@ -8,6 +8,7 @@ import {
   IsDefined,
   IsEmail,
   IsEnum,
+  IsOptional,
   IsString,
   ValidateNested
 } from "class-validator";
@@ -19,17 +20,36 @@ interface MemberData {
 }
 
 interface MemberProfileData {
+  telephone: string;
+  twitter: string;
+  preferredContact: string;
   deliveryOptIn: boolean;
   deliveryAddress?: Address;
   newsletterStatus: NewsletterStatus;
+  newsletterGroups: string[];
+
+  // Admin only
+  tags?: string[];
+  notes?: string;
+  description?: string;
 }
 
 export interface GetMemberData extends MemberData {
   joined: Date;
   contributionAmount?: number;
   contributionPeriod?: ContributionPeriod;
-  profile: MemberProfileData;
+  profile?: MemberProfileData;
   roles: PermissionType[];
+}
+
+export enum GetMemberWith {
+  Profile = "profile"
+}
+
+export class GetMemberQuery {
+  @IsEnum(GetMemberWith, { each: true })
+  @IsOptional()
+  with?: GetMemberWith[];
 }
 
 class UpdateAddressData implements Address {
@@ -50,6 +70,18 @@ class UpdateAddressData implements Address {
 }
 
 class UpdateMemberProfileData implements Partial<MemberProfileData> {
+  @IsString()
+  telephone?: string;
+
+  @IsString()
+  twitter?: string;
+
+  @IsString()
+  preferredContact?: string;
+
+  @IsString({ each: true })
+  newsletterGroups?: string[];
+
   @IsBoolean()
   deliveryOptIn?: boolean;
 
@@ -59,6 +91,16 @@ class UpdateMemberProfileData implements Partial<MemberProfileData> {
 
   @IsEnum(NewsletterStatus)
   newsletterStatus?: NewsletterStatus;
+
+  // Admin only
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsString()
+  notes?: string;
+
+  @IsString()
+  description?: string;
 }
 
 export class UpdateMemberData implements Partial<MemberData> {


### PR DESCRIPTION
- Added `with` query param to only return profile when needed
- Added new data to get/edit profile
- Changed PUT /member/me to PATCH for consistency

### API migration

Update member:
`PUT /member/me` -> `PATCH /member/me`

Get member
`GET /member/me` -> no change


Get member with profile
`GET /member/me` -> `GET /member/me?with[]=profile`