### PR TITLE
chore: support special fields for member search as segments already use them

### DIFF
--- a/src/api/controllers/SegmentController.ts
+++ b/src/api/controllers/SegmentController.ts
@@ -56,7 +56,7 @@ export class SegmentController {
               }
             : ruleGroup
         },
-        { withRestricted: true }
+        { withRestricted: true, with: query.with }
       );
     }
   }

--- a/src/api/data/MemberData.ts
+++ b/src/api/data/MemberData.ts
@@ -78,8 +78,31 @@ export class GetMemberQuery {
   with?: GetMemberWith[];
 }
 
-const fields = ["firstname", "lastname", "email"] as const;
-const sortFields = ["firstname", "email", "joined"] as const;
+const fields = [
+  "firstname",
+  "lastname",
+  "email",
+  "joined",
+  "lastSeen",
+  "contributionType",
+  "contributionMonthlyAmount",
+  "contributionPeriod",
+  // Special fields
+  "deliveryOptIn",
+  "newsletterStatus",
+  "activePermission",
+  "activeMembership",
+  "membershipExpires",
+  "tags"
+] as const;
+const sortFields = [
+  "firstname",
+  "lastname",
+  "email",
+  "joined",
+  "lastSeen",
+  "contributionMonthlyAmount"
+] as const;
 
 type Field = typeof fields[number];
 type SortField = typeof sortFields[number];

--- a/src/api/utils/pagination.ts
+++ b/src/api/utils/pagination.ts
@@ -91,7 +91,7 @@ export async function fetchPaginated<
     .offset(offset)
     .limit(limit);
   if (query.sort) {
-    qb.orderBy({ [query.sort]: query.order || "ASC" });
+    qb.orderBy({ ["item." + query.sort]: query.order || "ASC" });
   }
 
   if (queryCallback) {

--- a/src/core/utils/newRules.ts
+++ b/src/core/utils/newRules.ts
@@ -59,8 +59,9 @@ export type SpecialFields<Field extends string> = Partial<
     (
       rule: Rule<Field>,
       qb: WhereExpressionBuilder,
-      suffix: string
-    ) => Record<string, unknown> | undefined
+      suffix: string,
+      namedWhere: string
+    ) => Record<string, unknown> | undefined | void
   >
 >;
 
@@ -113,7 +114,7 @@ export function buildRuleQuery<Entity, Field extends string>(
 
       const specialField = specialFields && specialFields[rule.field];
       if (specialField) {
-        const specialRuleParams = specialField(rule, qb, suffix);
+        const specialRuleParams = specialField(rule, qb, suffix, namedWhere);
         if (specialRuleParams) {
           for (const paramKey in specialRuleParams) {
             params[paramKey + suffix] = specialRuleParams[paramKey];


### PR DESCRIPTION
Add support for some special fields for member queries as although they aren't visible in the new UI they are still used in segments created in the legacy app so it needs to work.

This is all quite hacky and mostly involves copying code from the old rules parser to the `fetchPaginatedMembers` method. We should revisit this when we look at how to make advanced search work going forwards