### PR TITLE
Stripe integation: GC abstraction

### DIFF
--- a/src/core/providers/payment/index.ts
+++ b/src/core/providers/payment/index.ts
@@ -1,0 +1,26 @@
+import { PaymentForm } from "@core/utils";
+
+import Member from "@models/Member";
+
+export interface PaymentRedirectFlowParams {
+  email: string;
+  firstname?: string;
+  lastname?: string;
+}
+
+export interface PaymentRedirectFlow {
+  id: string;
+  url: string;
+}
+
+export interface PaymentProvider {
+  createRedirectFlow(
+    sessionToken: string,
+    completeUrl: string,
+    params: PaymentRedirectFlowParams
+  ): Promise<PaymentRedirectFlow>;
+
+  hasPendingPayment(member: Member): Promise<boolean>;
+
+  cancelContribution(member: Member): Promise<void>;
+}

--- a/src/core/services/JoinFlowService.ts
+++ b/src/core/services/JoinFlowService.ts
@@ -28,18 +28,12 @@ class JoinFlowService {
       const redirectFlow = await GCPaymentService.createRedirectFlow(
         joinFlow.id,
         completeUrl,
-        {
-          prefilled_customer: {
-            email: user.email,
-            ...(user.firstname && { given_name: user.firstname }),
-            ...(user.lastname && { family_name: user.lastname })
-          }
-        }
+        user
       );
       await getRepository(JoinFlow).update(joinFlow.id, {
         redirectFlowId: redirectFlow.id
       });
-      return { joinFlow, redirectUrl: redirectFlow.redirect_url };
+      return { joinFlow, redirectUrl: redirectFlow.url };
     } else {
       return { joinFlow };
     }


### PR DESCRIPTION
The start of the Stripe integration:

* Use singleton pattern for `GCPaymentService` so it can inherit it's interface from `PaymentProvider`
* Abstract away from directly using GoCardless data structures (e.g. `prefilled_customer`) outside of GC services