### PR TITLE
Stripe integration: add stub Stripe payment provider

### DIFF
--- a/src/api/controllers/MemberController.ts
+++ b/src/api/controllers/MemberController.ts
@@ -21,7 +21,11 @@ import JoinFlowService from "@core/services/JoinFlowService";
 import MembersService from "@core/services/MembersService";
 import PaymentService from "@core/services/PaymentService";
 
-import { ContributionInfo, ContributionPeriod } from "@core/utils";
+import {
+  ContributionInfo,
+  ContributionPeriod,
+  PaymentMethod
+} from "@core/utils";
 import { generatePassword } from "@core/utils/auth";
 
 import Member from "@models/Member";
@@ -273,7 +277,8 @@ export class MemberController {
         monthlyAmount: data.monthlyAmount,
         // TODO: unnecessary, should be optional
         password: await generatePassword(""),
-        email: ""
+        email: "",
+        paymentMethod: PaymentMethod.DirectDebit
       },
       data.completeUrl,
       target

--- a/src/api/controllers/SignupController.ts
+++ b/src/api/controllers/SignupController.ts
@@ -10,7 +10,11 @@ import {
 } from "routing-controllers";
 import { getRepository } from "typeorm";
 
-import { ContributionPeriod, ContributionType } from "@core/utils";
+import {
+  ContributionPeriod,
+  ContributionType,
+  PaymentMethod
+} from "@core/utils";
 import { generatePassword } from "@core/utils/auth";
 
 import { NewsletterStatus } from "@core/providers/newsletter";
@@ -48,7 +52,8 @@ export class SignupController {
       monthlyAmount: data.contribution?.monthlyAmount || 0,
       period: data.contribution?.period || ContributionPeriod.Monthly,
       payFee: data.contribution?.payFee || false,
-      prorate: false
+      prorate: false,
+      paymentMethod: PaymentMethod.DirectDebit
     };
 
     if (data.contribution) {

--- a/src/core/providers/payment/index.ts
+++ b/src/core/providers/payment/index.ts
@@ -1,5 +1,7 @@
 import { PaymentForm } from "@core/utils";
 
+import Address from "@models/Address";
+import JoinFlow from "@models/JoinFlow";
 import Member from "@models/Member";
 
 export interface PaymentRedirectFlowParams {
@@ -13,14 +15,36 @@ export interface PaymentRedirectFlow {
   url: string;
 }
 
+export interface CompletedPaymentRedirectFlow {
+  customerId: string;
+  mandateId: string;
+}
+
 export interface PaymentProvider {
+  customerToMember(customerId: string): Promise<{
+    partialMember: Partial<Member>;
+    billingAddress: Address;
+  }>;
+
   createRedirectFlow(
-    sessionToken: string,
+    joinFlow: JoinFlow,
     completeUrl: string,
     params: PaymentRedirectFlowParams
   ): Promise<PaymentRedirectFlow>;
 
+  completeRedirectFlow(
+    joinFlow: JoinFlow
+  ): Promise<CompletedPaymentRedirectFlow>;
+
   hasPendingPayment(member: Member): Promise<boolean>;
 
   cancelContribution(member: Member): Promise<void>;
+
+  updateContribution(member: Member, paymentForm: PaymentForm): Promise<void>;
+
+  updatePaymentSource(
+    member: Member,
+    customerId: string,
+    mandateId: string
+  ): Promise<void>;
 }

--- a/src/core/services/StripePaymentService.ts
+++ b/src/core/services/StripePaymentService.ts
@@ -1,0 +1,48 @@
+import {
+  CompletedPaymentRedirectFlow,
+  PaymentProvider,
+  PaymentRedirectFlow,
+  PaymentRedirectFlowParams
+} from "@core/providers/payment";
+import { PaymentForm } from "@core/utils";
+import Address from "@models/Address";
+import JoinFlow from "@models/JoinFlow";
+import Member from "@models/Member";
+
+class StripePaymentService implements PaymentProvider {
+  completeRedirectFlow(
+    joinFlow: JoinFlow
+  ): Promise<CompletedPaymentRedirectFlow> {
+    throw new Error("Method not implemented.");
+  }
+  updatePaymentSource(
+    member: Member,
+    customerId: string,
+    mandateId: string
+  ): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  updateContribution(member: Member, paymentForm: PaymentForm): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  customerToMember(
+    customerId: string
+  ): Promise<{ partialMember: Partial<Member>; billingAddress: Address }> {
+    throw new Error("Method not implemented.");
+  }
+  createRedirectFlow(
+    joinFlow: JoinFlow,
+    completeUrl: string,
+    params: PaymentRedirectFlowParams
+  ): Promise<PaymentRedirectFlow> {
+    throw new Error("Method not implemented.");
+  }
+  hasPendingPayment(member: Member): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+  cancelContribution(member: Member): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export default new StripePaymentService();

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -35,6 +35,11 @@ export interface PaymentForm {
   prorate: boolean;
 }
 
+export enum PaymentMethod {
+  Card = "card",
+  DirectDebit = "direct-debit"
+}
+
 export interface PaymentSource {
   type: "direct-debit";
   bankName: string;

--- a/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
+++ b/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
@@ -1,3 +1,4 @@
+import { addThenSetNotNull } from "@core/utils/db";
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class AddPaymentMethodToJoinForm1650900384747
@@ -6,8 +7,11 @@ export class AddPaymentMethodToJoinForm1650900384747
   name = "AddPaymentMethodToJoinForm1650900384747";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "join_flow" ADD "joinFormPaymentmethod" character varying NOT NULL`
+    addThenSetNotNull(
+      queryRunner,
+      "join_flow",
+      "joinFormPaymentmethod",
+      "direct-debit"
     );
   }
 

--- a/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
+++ b/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
@@ -7,7 +7,7 @@ export class AddPaymentMethodToJoinForm1650900384747
   name = "AddPaymentMethodToJoinForm1650900384747";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    addThenSetNotNull(
+    await addThenSetNotNull(
       queryRunner,
       "join_flow",
       "joinFormPaymentmethod",

--- a/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
+++ b/src/migrations/1650900384747-AddPaymentMethodToJoinForm.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPaymentMethodToJoinForm1650900384747
+  implements MigrationInterface
+{
+  name = "AddPaymentMethodToJoinForm1650900384747";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "join_flow" ADD "joinFormPaymentmethod" character varying NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "join_flow" DROP COLUMN "joinFormPaymentmethod"`
+    );
+  }
+}

--- a/src/migrations/1650904701374-NonNullRedirectFlowId.ts
+++ b/src/migrations/1650904701374-NonNullRedirectFlowId.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NonNullRedirectFlowId1650904701374 implements MigrationInterface {
+  name = "NonNullRedirectFlowId1650904701374";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "join_flow" SET "redirectFlowId"='' WHERE "redirectFlowId" IS NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "join_flow" ALTER COLUMN "redirectFlowId" SET NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "join_flow" ALTER COLUMN "redirectFlowId" DROP NOT NULL`
+    );
+  }
+}

--- a/src/models/JoinFlow.ts
+++ b/src/models/JoinFlow.ts
@@ -15,8 +15,8 @@ export default class JoinFlow {
   @CreateDateColumn()
   date!: Date;
 
-  @Column({ type: String, nullable: true })
-  redirectFlowId!: string | null;
+  @Column()
+  redirectFlowId!: string;
 
   @Column(() => JoinForm)
   joinForm!: JoinForm;

--- a/src/models/JoinForm.ts
+++ b/src/models/JoinForm.ts
@@ -1,5 +1,5 @@
 import { Column } from "typeorm";
-import { ContributionPeriod, PaymentForm } from "@core/utils";
+import { ContributionPeriod, PaymentForm, PaymentMethod } from "@core/utils";
 import Password from "./Password";
 
 export interface ReferralGiftForm {
@@ -25,6 +25,9 @@ export default class JoinForm implements PaymentForm, ReferralGiftForm {
 
   @Column({ default: false })
   prorate!: boolean;
+
+  @Column()
+  paymentMethod!: PaymentMethod;
 
   @Column({ type: String, nullable: true })
   referralCode?: string | null;


### PR DESCRIPTION
Move all `GCPaymentService` calls to within `PaymentService` and create the stub `StripePaymentService`. This is a no-op change to live environments as there is no way of selecting the Stripe payment route, but it creates a layer of abstraction between GoCardless and the rest of the code to begin implementing Stripe payments