### PR TITLE
Add share/description for callouts

### DIFF
--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -149,7 +149,11 @@ export class CalloutController {
         thanksText: poll.thanksText,
         thanksTitle: poll.thanksTitle,
         formSchema: poll.formSchema,
-        ...(poll.thanksRedirect && { thanksRedirect: poll.thanksRedirect })
+        ...(poll.thanksRedirect && { thanksRedirect: poll.thanksRedirect }),
+        ...(poll.shareTitle && { shareTitle: poll.shareTitle }),
+        ...(poll.shareDescription && {
+          shareDescription: poll.shareDescription
+        })
       };
     }
   }

--- a/src/api/data/CalloutData.ts
+++ b/src/api/data/CalloutData.ts
@@ -73,6 +73,8 @@ interface MoreCalloutData extends BasicCalloutData {
   thanksTitle: string;
   thanksText: string;
   thanksRedirect?: string;
+  shareTitle?: string;
+  shareDescription?: string;
   formSchema: PollFormSchema;
 }
 
@@ -107,6 +109,14 @@ export class UpdateCalloutData implements Omit<MoreCalloutData, "slug"> {
   @IsOptional()
   @IsUrl()
   thanksRedirect?: string;
+
+  @IsOptional()
+  @IsString()
+  shareTitle?: string;
+
+  @IsOptional()
+  @IsString()
+  shareDescription?: string;
 
   @IsObject()
   formSchema!: PollFormSchema;

--- a/src/apps/settings/apps/content/views/index.pug
+++ b/src/apps/settings/apps/content/views/index.pug
@@ -80,7 +80,27 @@ block contents
                 input(type='checkbox' name="data[hideContribution]" value="true" checked=general.hideContribution)
                 | Hide contribution option
 
+        .row: .col-md-offset-3.col-md-9: h5 Share settings
+
+        .form-group
+          label.control-label.col-md-3 Twitter handle
+          .col-md-9
+            input(type='text' name='options[share-twitter-handle]' value=Options('share-twitter-handle')).form-control
+        .form-group
+          label.control-label.col-md-3 Share title
+          .col-md-9
+            input(type='text' name='options[share-title]' value=Options('share-title')).form-control
+        .form-group
+          label.control-label.col-md-3 Share description
+          .col-md-9
+            input(type='text' name='options[share-description]' value=Options('share-description')).form-control
+        .form-group
+          label.control-label.col-md-3 Share image URL
+          .col-md-9
+            input(type='text' name='options[share-image]' value=Options('share-image')).form-control
+
         .row: .col-md-offset-3.col-md-9: h5 Footer links
+
         ul(data-name="data[footerLinks]").no-list.js-repeater
           if general.footerLinks
             each link, i in general.footerLinks

--- a/src/apps/share/app.ts
+++ b/src/apps/share/app.ts
@@ -1,14 +1,49 @@
 import express from "express";
+import { getRepository } from "typeorm";
+
 import { wrapAsync } from "@core/utils";
+
+import PageSettingsService, {
+  JustPageSettings
+} from "@core/services/PageSettingsService";
+
+import Poll from "@models/Poll";
+
+import config from "@config";
 
 const app = express();
 
 app.set("views", __dirname + "/views");
 
+async function getCalloutShareSettings(
+  uri: string
+): Promise<JustPageSettings | undefined> {
+  const [slug, ...rest] = uri.substring("/callouts/".length).split("/", 1);
+
+  const callout = await getRepository(Poll).findOne(slug);
+  if (callout) {
+    return {
+      shareTitle: callout.shareTitle || callout.title,
+      shareDescription: callout.shareDescription || callout.excerpt,
+      shareImage: callout.image,
+      shareUrl: config.audience + "/callouts/" + callout.slug
+    };
+  }
+}
+
 app.get(
   "/",
   wrapAsync(async (req, res) => {
-    res.render("index");
+    let pageSettings: JustPageSettings | undefined;
+
+    const uri = req.query.uri ? req.query.uri.toString() : undefined;
+    if (uri) {
+      pageSettings = uri.startsWith("/callouts/")
+        ? await getCalloutShareSettings(uri)
+        : PageSettingsService.getPath(uri);
+    }
+
+    res.render("index", pageSettings && { pageSettings });
   })
 );
 

--- a/src/apps/share/app.ts
+++ b/src/apps/share/app.ts
@@ -1,0 +1,15 @@
+import express from "express";
+import { wrapAsync } from "@core/utils";
+
+const app = express();
+
+app.set("views", __dirname + "/views");
+
+app.get(
+  "/",
+  wrapAsync(async (req, res) => {
+    res.render("index");
+  })
+);
+
+export default app;

--- a/src/apps/share/config.json
+++ b/src/apps/share/config.json
@@ -1,0 +1,6 @@
+{
+  "title": "Share",
+  "path": "share",
+  "permissions": ["loggedOut"],
+  "menu": "none"
+}

--- a/src/apps/share/views/index.pug
+++ b/src/apps/share/views/index.pug
@@ -1,0 +1,6 @@
+doctype html
+html
+	head
+		meta( charset="utf-8" )
+		title= pageSettings.shareTitle
+		include /views/partials/share-meta.pug

--- a/src/core/services/PageSettingsService.ts
+++ b/src/core/services/PageSettingsService.ts
@@ -7,7 +7,7 @@ interface PageSettingsCache extends PageSettings {
   patternRegex: RegExp;
 }
 
-type JustPageSettings = Omit<PageSettings, "id" | "pattern">;
+export type JustPageSettings = Omit<PageSettings, "id" | "pattern">;
 
 export default class PageSettingsService {
   private static pathCache: Record<string, JustPageSettings | "default"> = {};

--- a/src/migrations/1652276361695-AddShareFieldsToPoll.ts
+++ b/src/migrations/1652276361695-AddShareFieldsToPoll.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddShareFieldsToPoll1652276361695 implements MigrationInterface {
+  name = "AddShareFieldsToPoll1652276361695";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "poll" ADD "shareTitle" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "poll" ADD "shareDescription" character varying`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "poll" DROP COLUMN "shareDescription"`
+    );
+    await queryRunner.query(`ALTER TABLE "poll" DROP COLUMN "shareTitle"`);
+  }
+}

--- a/src/models/Poll.ts
+++ b/src/models/Poll.ts
@@ -59,6 +59,12 @@ export default class Poll extends ItemWithStatus {
   @Column({ type: String, nullable: true })
   thanksRedirect!: string | null;
 
+  @Column({ type: String, nullable: true })
+  shareTitle!: string | null;
+
+  @Column({ type: String, nullable: true })
+  shareDescription!: string | null;
+
   @Column({ type: "jsonb", default: "{}" })
   formSchema!: PollFormSchema;
 


### PR DESCRIPTION
1. Adds the share title/description fields to the `Poll` model and equivalent API routes
2. Adds a new route `/share` which just responses with the things crawlers want to know.

The legacy app has a model called `PageSettings` which has historically been used to override these settings, for backwards compatibility the `/share` route will continue to support these