### PR TITLE
feat: improved callout responses API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^1.10.1",
+        "@beabee/beabee-common": "^1.10.2",
         "@sendgrid/mail": "^7.7.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -731,9 +731,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.1.tgz",
-      "integrity": "sha512-OdMkm5o7lJAdfkqQJhpxhvrtvKSkFiQV4a1fMt59o5prHhjhTNbMzki+aJjepEVNI2vIhMB7roakspi7tQoiXw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.2.tgz",
+      "integrity": "sha512-moMy0XyibJ1ND4ufdCnUe8w2iJzDH8K60pmSOfxX+q8lE5aiVKUNaoVmNdUaXHTGgreWntQv1cpoBYUBrod4cA==",
       "dependencies": {
         "date-fns": "^2.29.3"
       }
@@ -14666,9 +14666,9 @@
       "dev": true
     },
     "@beabee/beabee-common": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.1.tgz",
-      "integrity": "sha512-OdMkm5o7lJAdfkqQJhpxhvrtvKSkFiQV4a1fMt59o5prHhjhTNbMzki+aJjepEVNI2vIhMB7roakspi7tQoiXw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.2.tgz",
+      "integrity": "sha512-moMy0XyibJ1ND4ufdCnUe8w2iJzDH8K60pmSOfxX+q8lE5aiVKUNaoVmNdUaXHTGgreWntQv1cpoBYUBrod4cA==",
       "requires": {
         "date-fns": "^2.29.3"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^1.10.1",
+    "@beabee/beabee-common": "^1.10.2",
     "@sendgrid/mail": "^7.7.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -24,7 +24,6 @@ import Contact from "@models/Contact";
 import Callout from "@models/Callout";
 import CalloutResponse from "@models/CalloutResponse";
 
-import { UUIDParam } from "@api/data";
 import {
   convertCalloutToData,
   convertResponseToData,
@@ -35,6 +34,7 @@ import {
   GetCalloutData,
   GetCalloutQuery,
   GetCalloutResponseData,
+  GetCalloutResponseParam,
   GetCalloutResponseQuery,
   GetCalloutResponsesQuery,
   GetCalloutsQuery
@@ -152,8 +152,7 @@ export class CalloutController {
   @Get("/:slug/responses/:id")
   async getCalloutResponse(
     @CurrentUser() contact: Contact,
-    @Param("slug") slug: string,
-    @Params() { id }: UUIDParam,
+    @Params() param: GetCalloutResponseParam,
     @QueryParams() query: GetCalloutResponseQuery
   ): Promise<GetCalloutResponseData | undefined> {
     const response = await getRepository(CalloutResponse).findOne({

--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -37,6 +37,7 @@ import {
   GetCalloutResponseParam,
   GetCalloutResponseQuery,
   GetCalloutResponsesQuery,
+  GetCalloutResponseWith,
   GetCalloutsQuery
 } from "@api/data/CalloutData";
 import { Paginated } from "@api/data/PaginatedData";
@@ -156,10 +157,15 @@ export class CalloutController {
     @QueryParams() query: GetCalloutResponseQuery
   ): Promise<GetCalloutResponseData | undefined> {
     const response = await getRepository(CalloutResponse).findOne({
-      id,
-      callout: { slug },
-      // Non-admins can only see their own responses
-      ...(!contact.hasRole("admin") && { contact })
+      where: {
+        id: param.id,
+        callout: { slug: param.slug },
+        // Non-admins can only see their own responses
+        ...(!contact.hasRole("admin") && { contact })
+      },
+      relations: query.with?.includes(GetCalloutResponseWith.Contact)
+        ? ["contact", "contact.roles"]
+        : []
     });
 
     return response && convertResponseToData(response, query.with);

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -90,8 +90,8 @@ export function convertResponseToData(
     ...(_with?.includes(GetCalloutResponseWith.Answers) && {
       answers: response.answers
     }),
-    ...(response.contact && {
-      contact: convertContactToData(response.contact)
+    ...(_with?.includes(GetCalloutResponseWith.Contact) && {
+      contact: response.contact && convertContactToData(response.contact)
     })
   };
 }

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -196,6 +196,7 @@ export async function fetchPaginatedCalloutResponses(
   return {
     ...results,
     items: results.items.map((item) => ({
+      id: item.id,
       contact: item.contact as unknown as string, // TODO: fix typing
       answers: item.answers,
       createdAt: item.createdAt,

--- a/src/api/data/CalloutData/interface.ts
+++ b/src/api/data/CalloutData/interface.ts
@@ -17,6 +17,7 @@ import IsUrl from "@api/validators/IsUrl";
 
 import { CalloutFormSchema, CalloutAccess } from "@models/Callout";
 import { CalloutResponseAnswers } from "@models/CalloutResponse";
+import { GetContactData } from "../ContactData";
 
 export enum GetCalloutWith {
   Form = "form",
@@ -134,19 +135,28 @@ export class CreateCalloutData implements CalloutData {
   hidden!: boolean;
 }
 
+export enum GetCalloutResponseWith {
+  Answers = "answers",
+  Contact = "contact"
+}
+
 export const responseSortFields = ["createdAt", "updatedAt"] as const;
 
 export class GetCalloutResponsesQuery extends GetPaginatedQuery {
+  @IsOptional()
+  @IsEnum(GetCalloutResponseWith, { each: true })
+  with?: GetCalloutResponseWith[];
+
   @IsIn(responseSortFields)
   sort?: string;
 }
 
 export interface GetCalloutResponseData {
   id: string;
-  contact: string;
-  answers: CalloutResponseAnswers;
   createdAt: Date;
   updatedAt: Date;
+  answers?: CalloutResponseAnswers;
+  contact?: GetContactData;
 }
 
 export class CreateCalloutResponseData {

--- a/src/api/data/CalloutData/interface.ts
+++ b/src/api/data/CalloutData/interface.ts
@@ -142,6 +142,7 @@ export class GetCalloutResponsesQuery extends GetPaginatedQuery {
 }
 
 export interface GetCalloutResponseData {
+  id: string;
   contact: string;
   answers: CalloutResponseAnswers;
   createdAt: Date;

--- a/src/api/data/CalloutData/interface.ts
+++ b/src/api/data/CalloutData/interface.ts
@@ -168,7 +168,7 @@ export interface GetCalloutResponseData {
   createdAt: Date;
   updatedAt: Date;
   answers?: CalloutResponseAnswers;
-  contact?: GetContactData;
+  contact?: GetContactData | null;
 }
 
 export class CreateCalloutResponseData {

--- a/src/api/data/CalloutData/interface.ts
+++ b/src/api/data/CalloutData/interface.ts
@@ -18,6 +18,7 @@ import IsUrl from "@api/validators/IsUrl";
 import { CalloutFormSchema, CalloutAccess } from "@models/Callout";
 import { CalloutResponseAnswers } from "@models/CalloutResponse";
 import { GetContactData } from "../ContactData";
+import { UUIDParam } from "..";
 
 export enum GetCalloutWith {
   Form = "form",
@@ -144,6 +145,11 @@ export class GetCalloutResponseQuery {
   @IsOptional()
   @IsEnum(GetCalloutResponseWith, { each: true })
   with?: GetCalloutResponseWith[];
+}
+
+export class GetCalloutResponseParam extends UUIDParam {
+  @IsString()
+  slug!: string;
 }
 
 export const responseSortFields = ["createdAt", "updatedAt"] as const;

--- a/src/api/data/CalloutData/interface.ts
+++ b/src/api/data/CalloutData/interface.ts
@@ -140,6 +140,12 @@ export enum GetCalloutResponseWith {
   Contact = "contact"
 }
 
+export class GetCalloutResponseQuery {
+  @IsOptional()
+  @IsEnum(GetCalloutResponseWith, { each: true })
+  with?: GetCalloutResponseWith[];
+}
+
 export const responseSortFields = ["createdAt", "updatedAt"] as const;
 
 export class GetCalloutResponsesQuery extends GetPaginatedQuery {

--- a/src/api/data/ContactData/index.ts
+++ b/src/api/data/ContactData/index.ts
@@ -26,7 +26,7 @@ interface ConvertOpts {
 
 export function convertContactToData(
   contact: Contact,
-  opts: ConvertOpts
+  opts?: ConvertOpts
 ): GetContactData {
   const activeRoles = [...contact.activeRoles];
   if (activeRoles.includes("superadmin")) {
@@ -49,7 +49,7 @@ export function convertContactToData(
       contributionPeriod: contact.contributionPeriod
     }),
     activeRoles,
-    ...(opts.with?.includes(GetContactWith.Profile) &&
+    ...(opts?.with?.includes(GetContactWith.Profile) &&
       contact.profile && {
         profile: {
           telephone: contact.profile.telephone,
@@ -66,7 +66,7 @@ export function convertContactToData(
           })
         }
       }),
-    ...(opts.with?.includes(GetContactWith.Roles) && {
+    ...(opts?.with?.includes(GetContactWith.Roles) && {
       roles: contact.roles.map((p) => ({
         role: p.type,
         dateAdded: p.dateAdded,


### PR DESCRIPTION
A few improvements to the callout responses API
* Added the `id` to the callout response data
* Added a new route `/callout/<slug>/responses/<id>` to fetch an individual response.
* Introduce `with` query param for fetching responses
  * `answers`: add the `answers` field to the response
  * `contact`: add an expanded `contact` field to the response
* Bumped `beabee-common` to add `createdAt` and `updatedAt` as fields that can be filtered on when paginating over responses.