### PR TITLE
Copy and prune node modules in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ WORKDIR /opt/membership-system
 
 COPY package.json package-lock.json /opt/membership-system/
 COPY --chown=node:node --from=builder /opt/membership-system/node_modules /opt/membership-system/node_modules
-#RUN npm ci --only=production
 RUN npm prune
 
 COPY --chown=node:node --from=builder /opt/membership-system/built /opt/membership-system/built

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:16.18-alpine as builder
 
-RUN apk add --no-cache make g++ git
+RUN apk add --no-cache make g++ git gcc libgcc libstdc++ linux-headers python3
+RUN npm install -g node-gyp 
 
 WORKDIR /opt/membership-system
 
@@ -20,10 +21,14 @@ FROM node:16.18-alpine as app
 
 ARG REVISION=DEV
 
+ENV NODE_ENV=production
+
 WORKDIR /opt/membership-system
 
 COPY package.json package-lock.json /opt/membership-system/
-RUN npm ci --only=production
+COPY --chown=node:node --from=builder /opt/membership-system/node_modules /opt/membership-system/node_modules
+#RUN npm ci --only=production
+RUN npm prune
 
 COPY --chown=node:node --from=builder /opt/membership-system/built /opt/membership-system/built
 


### PR DESCRIPTION
Node modules are now copied from the build stage instead of re-installed. Solves a problem with muhammara and should make the build quicker. 