### PR TITLE
feat: add response bucket and batch updating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^1.10.12",
+        "@beabee/beabee-common": "^1.10.14",
         "@sendgrid/mail": "^7.7.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -731,9 +731,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.12.tgz",
-      "integrity": "sha512-tvpdpRQtZ2iy+g/TuSlk7jrvcrND3xo6itzwp9DFC7Z0XVV55Nt7npuMG+uGkP0xpkE+VM76mCqgL7HHCgShHQ==",
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.14.tgz",
+      "integrity": "sha512-I+YrUGP84Be5uVHu+me9WFT5+RgRmdUwbZhHKFVDONdIQVkAoMBnMU5e8GibRxYxWoOSnwL/O3DDUbyEugCkZA==",
       "dependencies": {
         "date-fns": "^2.29.3"
       }
@@ -14672,9 +14672,9 @@
       "dev": true
     },
     "@beabee/beabee-common": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.12.tgz",
-      "integrity": "sha512-tvpdpRQtZ2iy+g/TuSlk7jrvcrND3xo6itzwp9DFC7Z0XVV55Nt7npuMG+uGkP0xpkE+VM76mCqgL7HHCgShHQ==",
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.14.tgz",
+      "integrity": "sha512-I+YrUGP84Be5uVHu+me9WFT5+RgRmdUwbZhHKFVDONdIQVkAoMBnMU5e8GibRxYxWoOSnwL/O3DDUbyEugCkZA==",
       "requires": {
         "date-fns": "^2.29.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^1.10.14",
+        "@beabee/beabee-common": "^1.10.16",
         "@sendgrid/mail": "^7.7.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -731,9 +731,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.14.tgz",
-      "integrity": "sha512-I+YrUGP84Be5uVHu+me9WFT5+RgRmdUwbZhHKFVDONdIQVkAoMBnMU5e8GibRxYxWoOSnwL/O3DDUbyEugCkZA==",
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.16.tgz",
+      "integrity": "sha512-eWNIVkzSJqFwbfgaZdwo00AT0YezZh7jbGO6Sar+JAfAPCh6LKTAAaJZ/BeSDjsP52cy3HpqHpm+qinMeAN8Vg==",
       "dependencies": {
         "date-fns": "^2.29.3"
       }
@@ -14672,9 +14672,9 @@
       "dev": true
     },
     "@beabee/beabee-common": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.14.tgz",
-      "integrity": "sha512-I+YrUGP84Be5uVHu+me9WFT5+RgRmdUwbZhHKFVDONdIQVkAoMBnMU5e8GibRxYxWoOSnwL/O3DDUbyEugCkZA==",
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.16.tgz",
+      "integrity": "sha512-eWNIVkzSJqFwbfgaZdwo00AT0YezZh7jbGO6Sar+JAfAPCh6LKTAAaJZ/BeSDjsP52cy3HpqHpm+qinMeAN8Vg==",
       "requires": {
         "date-fns": "^2.29.3"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^1.10.12",
+    "@beabee/beabee-common": "^1.10.14",
     "@sendgrid/mail": "^7.7.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^1.10.14",
+    "@beabee/beabee-common": "^1.10.16",
     "@sendgrid/mail": "^7.7.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/src/api/controllers/CalloutResponseController.ts
+++ b/src/api/controllers/CalloutResponseController.ts
@@ -1,26 +1,41 @@
 import { Paginated } from "@beabee/beabee-common";
 import {
+  Authorized,
   CurrentUser,
   Get,
   JsonController,
+  Patch,
   QueryParams
 } from "routing-controllers";
 
 import {
+  BatchUpdateCalloutResponseData,
+  batchUpdateCalloutResponses,
   fetchPaginatedCalloutResponses,
   GetCalloutResponseData,
   GetCalloutResponsesQuery
 } from "@api/data/CalloutResponseData";
+import PartialBody from "@api/decorators/PartialBody";
 
 import Contact from "@models/Contact";
 
 @JsonController("/callout-responses")
 export class CalloutResponseController {
   @Get("/")
-  getCalloutResponses(
+  async getCalloutResponses(
     @CurrentUser() contact: Contact,
     @QueryParams() query: GetCalloutResponsesQuery
   ): Promise<Paginated<GetCalloutResponseData>> {
-    return fetchPaginatedCalloutResponses(query, contact);
+    return await fetchPaginatedCalloutResponses(query, contact);
+  }
+
+  @Authorized("admin")
+  @Patch("/")
+  async updateCalloutResponses(
+    @CurrentUser() contact: Contact,
+    @PartialBody() data: BatchUpdateCalloutResponseData
+  ): Promise<{ affected: number }> {
+    const affected = await batchUpdateCalloutResponses(data, contact);
+    return { affected };
   }
 }

--- a/src/api/controllers/ContactController.ts
+++ b/src/api/controllers/ContactController.ts
@@ -294,9 +294,14 @@ export class ContactController {
     @TargetUser() target: Contact,
     @QueryParams() query: GetPaymentsQuery
   ): Promise<Paginated<GetPaymentData>> {
-    const targetQuery = mergeRules(query, [
-      { field: "contact", operator: "equal", value: [target.id] }
-    ]);
+    const targetQuery = {
+      ...query,
+      rules: mergeRules([
+        query.rules,
+        { field: "contact", operator: "equal", value: [target.id] }
+      ])
+    };
+
     const data = await fetchPaginated(
       Payment,
       paymentFilters,

--- a/src/api/controllers/NoticeController.ts
+++ b/src/api/controllers/NoticeController.ts
@@ -41,14 +41,19 @@ export class NoticeController {
     @CurrentUser() contact: Contact,
     @QueryParams() query: GetNoticesQuery
   ): Promise<Paginated<GetNoticeData>> {
-    const authedQuery = mergeRules(query, [
-      // Non-admins can only see open notices
-      !contact.hasRole("admin") && {
-        field: "status",
-        operator: "equal",
-        value: [ItemStatus.Open]
-      }
-    ]);
+    const authedQuery = {
+      ...query,
+      rules: mergeRules([
+        query.rules,
+        // Non-admins can only see open notices
+        !contact.hasRole("admin") && {
+          field: "status",
+          operator: "equal",
+          value: [ItemStatus.Open]
+        }
+      ])
+    };
+
     const results = await fetchPaginated(
       Notice,
       noticeFilters,

--- a/src/api/controllers/NoticeController.ts
+++ b/src/api/controllers/NoticeController.ts
@@ -28,7 +28,7 @@ import {
   fetchPaginated,
   mergeRules,
   Paginated,
-  statusField
+  statusFieldHandler
 } from "@api/data/PaginatedData";
 
 import PartialBody from "@api/decorators/PartialBody";
@@ -59,7 +59,7 @@ export class NoticeController {
       noticeFilters,
       authedQuery,
       contact,
-      { status: statusField }
+      { status: statusFieldHandler }
     );
 
     return {

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -95,20 +95,23 @@ export async function fetchPaginatedCallouts(
   query: GetCalloutsQuery,
   contact: Contact | undefined
 ): Promise<Paginated<GetCalloutData>> {
-  const scopedQuery = mergeRules(
-    query,
-    !contact?.hasRole("admin") && [
-      // Non-admins can only query for open or ended non-hidden callouts
-      {
-        condition: "OR",
-        rules: [
-          { field: "status", operator: "equal", value: [ItemStatus.Open] },
-          { field: "status", operator: "equal", value: [ItemStatus.Ended] }
-        ]
-      },
-      { field: "hidden", operator: "equal", value: [false] }
-    ]
-  );
+  const scopedQuery = contact?.hasRole("admin")
+    ? query
+    : {
+        ...query,
+        rules: mergeRules([
+          query.rules,
+          // Non-admins can only query for open or ended non-hidden callouts
+          {
+            condition: "OR",
+            rules: [
+              { field: "status", operator: "equal", value: [ItemStatus.Open] },
+              { field: "status", operator: "equal", value: [ItemStatus.Ended] }
+            ]
+          },
+          { field: "hidden", operator: "equal", value: [false] }
+        ])
+      };
 
   const results = await fetchPaginated(
     Callout,

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -144,12 +144,15 @@ export async function fetchPaginatedCallouts(
           .where(args.whereFn(`pr.contactId`))
           .orderBy("pr.calloutSlug");
 
-        qb.where("item.slug IN " + subQb.getQuery());
+        qb.where(`${args.fieldPrefix}slug IN ${subQb.getQuery()}`);
       }
     },
-    (qb) => {
+    (qb, fieldPrefix) => {
       if (contact && query.with?.includes(GetCalloutWith.ResponseCount)) {
-        qb.loadRelationCountAndMap("item.responseCount", "item.responses");
+        qb.loadRelationCountAndMap(
+          `${fieldPrefix}responseCount`,
+          `${fieldPrefix}responses`
+        );
       }
     }
   );

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -31,6 +31,7 @@ export function convertResponseToData(
     id: response.id,
     createdAt: response.createdAt,
     updatedAt: response.updatedAt,
+    bucket: response.bucket,
     ...(_with?.includes(GetCalloutResponseWith.Answers) && {
       answers: response.answers
     }),

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -3,7 +3,8 @@ import {
   calloutResponseFilters,
   FilterType,
   convertComponentsToFilters,
-  RuleOperator
+  RuleOperator,
+  Filters
 } from "@beabee/beabee-common";
 import { NotFoundError } from "routing-controllers";
 import { FindConditions, getRepository } from "typeorm";
@@ -14,13 +15,21 @@ import Contact from "@models/Contact";
 
 import { convertCalloutToData } from "../CalloutData";
 import { convertContactToData } from "../ContactData";
-import { mergeRules, fetchPaginated, FieldHandler } from "../PaginatedData";
+import {
+  mergeRules,
+  fetchPaginated,
+  FieldHandler,
+  batchUpdate,
+  FieldHandlers,
+  GetPaginatedRuleGroup
+} from "../PaginatedData";
 
 import {
   GetCalloutResponseWith,
   GetCalloutResponseData,
   GetCalloutResponsesQuery,
-  GetCalloutResponseQuery
+  GetCalloutResponseQuery,
+  BatchUpdateCalloutResponseData
 } from "./interface";
 
 export function convertResponseToData(
@@ -110,12 +119,13 @@ const answersFieldHandler: FieldHandler = (qb, args) => {
   }
 };
 
-export async function fetchPaginatedCalloutResponses(
-  query: GetCalloutResponsesQuery,
+async function prepareQuery(
+  ruleGroup: GetPaginatedRuleGroup | undefined,
   contact: Contact,
   calloutSlug?: string
-): Promise<Paginated<GetCalloutResponseData>> {
-  const scopedQuery = mergeRules(query, [
+): Promise<[GetPaginatedRuleGroup, Filters<string>, FieldHandlers<string>]> {
+  const scopedRules = mergeRules([
+    ruleGroup,
     // Non admins can only see their own responses
     !contact.hasRole("admin") && {
       field: "contact",
@@ -131,24 +141,44 @@ export async function fetchPaginatedCalloutResponses(
   ]);
 
   // If looking for responses for a particular callout then add answer filtering
-  let answerFilters, fieldHandlers;
   if (calloutSlug) {
     const callout = await getRepository(Callout).findOne(calloutSlug);
     if (!callout) {
       throw new NotFoundError();
     }
 
-    answerFilters = convertComponentsToFilters(callout.formSchema.components);
+    const answerFilters = convertComponentsToFilters(
+      callout.formSchema.components
+    );
     // All handled by the same field handler
-    fieldHandlers = Object.fromEntries(
+    const fieldHandlers = Object.fromEntries(
       Object.keys(answerFilters).map((field) => [field, answersFieldHandler])
     );
+    return [
+      scopedRules,
+      { ...calloutResponseFilters, ...answerFilters },
+      fieldHandlers
+    ];
+  } else {
+    return [scopedRules, calloutResponseFilters, {}];
   }
+}
+
+export async function fetchPaginatedCalloutResponses(
+  query: GetCalloutResponsesQuery,
+  contact: Contact,
+  calloutSlug?: string
+): Promise<Paginated<GetCalloutResponseData>> {
+  const [rules, filters, fieldHandlers] = await prepareQuery(
+    query.rules,
+    contact,
+    calloutSlug
+  );
 
   const results = await fetchPaginated(
     CalloutResponse,
-    { ...calloutResponseFilters, ...answerFilters },
-    scopedQuery,
+    filters,
+    { ...query, rules },
     contact,
     fieldHandlers,
     (qb) => {
@@ -166,6 +196,24 @@ export async function fetchPaginatedCalloutResponses(
     ...results,
     items: results.items.map((item) => convertResponseToData(item, query.with))
   };
+}
+
+export async function batchUpdateCalloutResponses(
+  data: BatchUpdateCalloutResponseData,
+  contact: Contact
+): Promise<number> {
+  const [rules, filters, fieldHandlers] = await prepareQuery(
+    data.rules,
+    contact
+  );
+  return await batchUpdate(
+    CalloutResponse,
+    filters,
+    rules,
+    data.updates,
+    contact,
+    fieldHandlers
+  );
 }
 
 export * from "./interface";

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -1,16 +1,22 @@
 import { CalloutResponseAnswers } from "@models/CalloutResponse";
+import { Type } from "class-transformer";
 import {
   IsOptional,
   IsEnum,
   IsString,
   IsIn,
   IsObject,
-  IsEmail
+  IsEmail,
+  IsArray,
+  IsUUID,
+  Validate,
+  ValidateNested,
+  IsDefined
 } from "class-validator";
 import { UUIDParam } from "..";
 import { GetCalloutData } from "../CalloutData";
 import { GetContactData } from "../ContactData";
-import { GetPaginatedQuery } from "../PaginatedData";
+import { GetPaginatedQuery, GetPaginatedRuleGroup } from "../PaginatedData";
 
 export enum GetCalloutResponseWith {
   Answers = "answers",
@@ -61,4 +67,19 @@ export class CreateCalloutResponseData {
   @IsOptional()
   @IsEmail()
   guestEmail?: string;
+
+  @IsOptional()
+  @IsString()
+  bucket?: string;
+}
+
+export class BatchUpdateCalloutResponseData {
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => GetPaginatedRuleGroup)
+  rules?: GetPaginatedRuleGroup;
+
+  @ValidateNested()
+  @Type(() => CreateCalloutResponseData)
+  updates!: CreateCalloutResponseData;
 }

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -44,6 +44,7 @@ export interface GetCalloutResponseData {
   id: string;
   createdAt: Date;
   updatedAt: Date;
+  bucket: string | null;
   answers?: CalloutResponseAnswers;
   callout?: GetCalloutData;
   contact?: GetContactData | null;

--- a/src/api/data/PaginatedData/index.ts
+++ b/src/api/data/PaginatedData/index.ts
@@ -141,6 +141,14 @@ const dateUnitSql = {
   s: "second"
 } as const;
 
+function noopField(field: string): string {
+  return field;
+}
+
+function coalesceField(field: string): string {
+  return `COALESCE(${field}, '')`;
+}
+
 function prepareRule(
   rule: ValidatedRule<string>,
   contact: Contact | undefined
@@ -148,7 +156,7 @@ function prepareRule(
   switch (rule.type) {
     case "text":
       // Make NULL an empty string for comparison
-      return [(field) => `COALESCE(${field}, '')`, rule.value];
+      return [rule.nullable ? coalesceField : noopField, rule.value];
 
     case "date": {
       // Compare dates by at least day, but more specific if H/m/s are provided
@@ -165,10 +173,10 @@ function prepareRule(
         throw new Error("No contact provided to map contact field type");
       }
       // Map "me" to contact id
-      return [(s) => s, rule.value.map((v) => (v === "me" ? contact.id : v))];
+      return [noopField, rule.value.map((v) => (v === "me" ? contact.id : v))];
 
     default:
-      return [(s) => s, rule.value];
+      return [noopField, rule.value];
   }
 }
 

--- a/src/api/data/PaginatedData/interface.ts
+++ b/src/api/data/PaginatedData/interface.ts
@@ -96,6 +96,7 @@ export type RichRuleValue = RuleValue | Date;
 export type FieldHandler = (
   qb: WhereExpressionBuilder,
   args: {
+    fieldPrefix: string;
     type: FilterType;
     field: string;
     operator: RuleOperator;

--- a/src/core/services/SegmentService.ts
+++ b/src/core/services/SegmentService.ts
@@ -8,7 +8,7 @@ import {
   fetchPaginatedContacts,
   contactFieldHandlers
 } from "@api/data/ContactData";
-import { buildQuery } from "@api/data/PaginatedData";
+import { buildSelectQuery } from "@api/data/PaginatedData";
 
 class SegmentService {
   async createSegment(
@@ -48,7 +48,7 @@ class SegmentService {
       contactFilters,
       segment.ruleGroup
     );
-    const qb = buildQuery(
+    const qb = buildSelectQuery(
       Contact,
       validatedRuleGroup,
       undefined,

--- a/src/migrations/1676460782435-AddCalloutResponseBucket.ts
+++ b/src/migrations/1676460782435-AddCalloutResponseBucket.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCalloutResponseBucket1676460782435
+  implements MigrationInterface
+{
+  name = "AddCalloutResponseBucket1676460782435";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD "bucket" character varying`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP COLUMN "bucket"`
+    );
+  }
+}

--- a/src/models/CalloutResponse.ts
+++ b/src/models/CalloutResponse.ts
@@ -47,4 +47,7 @@ export default class CalloutResponse {
 
   @UpdateDateColumn()
   updatedAt!: Date;
+
+  @Column({ type: String, nullable: true })
+  bucket!: string | null;
 }


### PR DESCRIPTION
Adds the bucket field to the `CalloutResponse` table and creates a new endpoint for batch updating callout responses. It uses a new `batchUpdate` method which works similarly to `fetchPaginated` by taking a `RuleGroup` which defines what will be updated.

Previous `fetchPaginated` aliased the main database table you were fetching as `item` to make it it simple to add more clauses to the query, e.g.
```
qb.where("item.id = :id")
```
TypeORM then takes care of mapping columns to their database names. Unfortunately TypeORM doesn't support alias on updates (https://github.com/typeorm/typeorm/issues/1798) so I rewrote the code to accept a `fieldPrefix` argument which can be empty so that the target table in the UPDATE query is not aliased.

All this means that we can use the same powerful `RuleGroup` logic to build where clauses for SELECT and UPDATE statements.

### New endpoints

`PATCH /callout-responses`: Batch update callout responses that match a given filter

Expected body:
```
{
  "rules": RuleGroup,
  "updates": Partial<UpdateCalloutResponseData>
}
```

e.g. Move all callout responses in the verified bucket to the finished bucket.
```json
{
  "rules": {"condition": "AND", "rules": [{"field": "bucket", "operator": "equal", "value": ["verified"]}]},
  "updates": {
    "bucket": "finished"
  }
}
```
