### PR TITLE
feat: add callout response tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^1.10.16",
+        "@beabee/beabee-common": "^1.10.17",
         "@sendgrid/mail": "^7.7.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -731,9 +731,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.16.tgz",
-      "integrity": "sha512-eWNIVkzSJqFwbfgaZdwo00AT0YezZh7jbGO6Sar+JAfAPCh6LKTAAaJZ/BeSDjsP52cy3HpqHpm+qinMeAN8Vg==",
+      "version": "1.10.17",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.17.tgz",
+      "integrity": "sha512-ApHhmZzMcg7fJ0rCzHK42V7AnF7oDWJ/u+PuexRkO8CoRN26+6sibRL0xt9s3zScMi1wSIdKVn4UlEAoZa0WFw==",
       "dependencies": {
         "date-fns": "^2.29.3"
       }
@@ -14672,9 +14672,9 @@
       "dev": true
     },
     "@beabee/beabee-common": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.16.tgz",
-      "integrity": "sha512-eWNIVkzSJqFwbfgaZdwo00AT0YezZh7jbGO6Sar+JAfAPCh6LKTAAaJZ/BeSDjsP52cy3HpqHpm+qinMeAN8Vg==",
+      "version": "1.10.17",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.17.tgz",
+      "integrity": "sha512-ApHhmZzMcg7fJ0rCzHK42V7AnF7oDWJ/u+PuexRkO8CoRN26+6sibRL0xt9s3zScMi1wSIdKVn4UlEAoZa0WFw==",
       "requires": {
         "date-fns": "^2.29.3"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^1.10.16",
+    "@beabee/beabee-common": "^1.10.17",
     "@sendgrid/mail": "^7.7.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -281,6 +281,7 @@ export async function batchUpdateCalloutResponses(
         .insert()
         .into(CalloutResponseTag)
         .values(addTags)
+        .orIgnore()
         .execute();
     }
     if (removeTags.length > 0) {

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -11,9 +11,11 @@ import { createQueryBuilder, FindConditions, getRepository } from "typeorm";
 
 import Callout from "@models/Callout";
 import CalloutResponse from "@models/CalloutResponse";
+import CalloutResponseTag from "@models/CalloutResponseTag";
 import Contact from "@models/Contact";
 
 import { convertCalloutToData } from "../CalloutData";
+import { convertTagToData } from "../CalloutTagData";
 import { convertContactToData } from "../ContactData";
 import {
   mergeRules,
@@ -31,7 +33,6 @@ import {
   GetCalloutResponseQuery,
   BatchUpdateCalloutResponseData
 } from "./interface";
-import CalloutResponseTag from "@models/CalloutResponseTag";
 
 export function convertResponseToData(
   response: CalloutResponse,
@@ -53,7 +54,7 @@ export function convertResponseToData(
     }),
     ...(_with?.includes(GetCalloutResponseWith.Tags) &&
       response.tags && {
-        tags: response.tags.map((rt) => ({ id: rt.tag.id, name: rt.tag.name }))
+        tags: response.tags.map((rt) => convertTagToData(rt.tag))
       })
   };
 }

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -21,7 +21,8 @@ import { GetPaginatedQuery, GetPaginatedRuleGroup } from "../PaginatedData";
 export enum GetCalloutResponseWith {
   Answers = "answers",
   Callout = "callout",
-  Contact = "contact"
+  Contact = "contact",
+  Tags = "tags"
 }
 
 export class GetCalloutResponseQuery {
@@ -54,6 +55,7 @@ export interface GetCalloutResponseData {
   answers?: CalloutResponseAnswers;
   callout?: GetCalloutData;
   contact?: GetContactData | null;
+  tags?: { id: string; name: string }[];
 }
 
 export class CreateCalloutResponseData {

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -15,6 +15,7 @@ import {
 } from "class-validator";
 import { UUIDParam } from "..";
 import { GetCalloutData } from "../CalloutData";
+import { GetCalloutTagData } from "../CalloutTagData";
 import { GetContactData } from "../ContactData";
 import { GetPaginatedQuery, GetPaginatedRuleGroup } from "../PaginatedData";
 
@@ -55,7 +56,7 @@ export interface GetCalloutResponseData {
   answers?: CalloutResponseAnswers;
   callout?: GetCalloutData;
   contact?: GetContactData | null;
-  tags?: { id: string; name: string }[];
+  tags?: GetCalloutTagData[];
 }
 
 export class CreateCalloutResponseData {

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -74,6 +74,10 @@ export class CreateCalloutResponseData {
   @IsOptional()
   @IsString()
   bucket?: string;
+
+  @IsOptional()
+  @IsString({ each: true })
+  tags?: string[];
 }
 
 export class BatchUpdateCalloutResponseData {

--- a/src/api/data/CalloutTagData/index.ts
+++ b/src/api/data/CalloutTagData/index.ts
@@ -1,0 +1,11 @@
+import CalloutTag from "@models/CalloutTag";
+import { GetCalloutTagData } from "./interface";
+
+export function convertTagToData(tag: CalloutTag): GetCalloutTagData {
+  return {
+    id: tag.id,
+    name: tag.name
+  };
+}
+
+export * from "./interface";

--- a/src/api/data/CalloutTagData/interface.ts
+++ b/src/api/data/CalloutTagData/interface.ts
@@ -1,0 +1,14 @@
+import { IsString } from "class-validator";
+
+export interface GetCalloutTagData {
+  id: string;
+  name: string;
+}
+
+export class CreateCalloutTagData {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  description!: string;
+}

--- a/src/migrations/1676654870090-AddCalloutTag.ts
+++ b/src/migrations/1676654870090-AddCalloutTag.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCalloutTag1676654870090 implements MigrationInterface {
+  name = "AddCalloutTag1676654870090";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "callout_tag" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "description" character varying NOT NULL, "calloutSlug" character varying, CONSTRAINT "PK_a976b7ebc872c92866b17e749d3" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_tag" ADD CONSTRAINT "FK_2d38f2b925681272ee3a0c65570" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_tag" DROP CONSTRAINT "FK_2d38f2b925681272ee3a0c65570"`
+    );
+    await queryRunner.query(`DROP TABLE "callout_tag"`);
+  }
+}

--- a/src/migrations/1676655715419-AddCalloutResponseTag.ts
+++ b/src/migrations/1676655715419-AddCalloutResponseTag.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCalloutResponseTag1676655715419 implements MigrationInterface {
+  name = "AddCalloutResponseTag1676655715419";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "callout_response_tag" ("date" TIMESTAMP NOT NULL DEFAULT now(), "responseId" uuid NOT NULL, "tagId" uuid NOT NULL, CONSTRAINT "PK_77ab6ecb2c6a56ec6d6904f790d" PRIMARY KEY ("responseId", "tagId"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_tag" ADD CONSTRAINT "FK_77210a0adf6d9a5bf80eb56b56a" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_tag" ADD CONSTRAINT "FK_1b1b51e6fdc38b7dead79300386" FOREIGN KEY ("tagId") REFERENCES "callout_tag"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_tag" DROP CONSTRAINT "FK_1b1b51e6fdc38b7dead79300386"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_tag" DROP CONSTRAINT "FK_77210a0adf6d9a5bf80eb56b56a"`
+    );
+    await queryRunner.query(`DROP TABLE "callout_response_tag"`);
+  }
+}

--- a/src/models/CalloutResponse.ts
+++ b/src/models/CalloutResponse.ts
@@ -3,12 +3,14 @@ import {
   CreateDateColumn,
   Entity,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn
 } from "typeorm";
 
 import type Contact from "./Contact";
 import type Callout from "./Callout";
+import CalloutResponseTag from "./CalloutResponseTag";
 
 export type CalloutResponseAnswer =
   | string
@@ -50,4 +52,7 @@ export default class CalloutResponse {
 
   @Column({ type: String, nullable: true })
   bucket!: string | null;
+
+  @OneToMany("CalloutResponseTag", "response")
+  tags!: CalloutResponseTag[];
 }

--- a/src/models/CalloutResponseTag.ts
+++ b/src/models/CalloutResponseTag.ts
@@ -1,0 +1,15 @@
+import { CreateDateColumn, Entity, ManyToOne } from "typeorm";
+import CalloutResponse from "./CalloutResponse";
+import CalloutTag from "./CalloutTag";
+
+@Entity({})
+export default class CalloutResponseTag {
+  @ManyToOne("CalloutResponse", "tags", { primary: true })
+  response!: CalloutResponse;
+
+  @ManyToOne("CalloutTag", { primary: true })
+  tag!: CalloutTag;
+
+  @CreateDateColumn()
+  date!: Date;
+}

--- a/src/models/CalloutTag.ts
+++ b/src/models/CalloutTag.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import Callout from "./Callout";
+
+@Entity()
+export default class CalloutTag {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @Column()
+  description!: string;
+
+  @ManyToOne("Callout")
+  callout!: Callout;
+}


### PR DESCRIPTION
This PR introduces the schema changes and necessary endpoints to tag callout responses.

A callout has a list of valid tags (`CalloutTag` model) and a response can be tagged with one of these (`CalloutResponseTag` model).

### New endpoints

* `GET /callout/:slug/tags`: Get list of possible tags for a callout
* `POST /callout/:slug/tags`: Add a new tag for a callout
* `PATCH /callout/:slug/tags/:id` Updates a tag

### Updated endpoints

`PATCH /callout-responses`: This endpoint can now add or remove tags from callout responses

Each tag ID in the new `tags` property on `UpdateCalloutResponseData` should be preceded by a `+` or `-` which indicates whether to add or remove the tag respectively.

e.g. Add tag1 and remove tag2 for all callout responses in the verified bucket
```json
{
  "rules": {"condition": "AND", "rules": [{"field": "bucket", "operator": "equal", "value": ["verified"]}]},
  "updates": {
    "tags": ["+tag1", "-tag2"]
  }
}
```
<b>NOTE:</b> In reality tag1 and tag2 would be UUIDs