### PR TITLE
Add endpoint to export responses

### DIFF
--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -1,4 +1,5 @@
 import { CalloutFormSchema } from "@beabee/beabee-common";
+import { Response } from "express";
 import {
   Authorized,
   Body,
@@ -11,7 +12,8 @@ import {
   Param,
   Patch,
   Post,
-  QueryParams
+  QueryParams,
+  Res
 } from "routing-controllers";
 import slugify from "slugify";
 import { getRepository } from "typeorm";
@@ -38,6 +40,8 @@ import {
 } from "@api/data/CalloutData";
 import {
   CreateCalloutResponseData,
+  exportCalloutResponses,
+  ExportCalloutResponsesQuery,
   fetchPaginatedCalloutResponses,
   GetCalloutResponseData,
   GetCalloutResponsesQuery
@@ -125,6 +129,22 @@ export class CalloutController {
     @QueryParams() query: GetCalloutResponsesQuery
   ): Promise<Paginated<GetCalloutResponseData>> {
     return await fetchPaginatedCalloutResponses(query, contact, slug);
+  }
+
+  @Get("/:slug/responses.csv")
+  async exportCalloutResponses(
+    @CurrentUser() contact: Contact,
+    @Param("slug") slug: string,
+    @QueryParams() query: ExportCalloutResponsesQuery,
+    @Res() res: Response
+  ): Promise<Response> {
+    const [exportName, exportData] = await exportCalloutResponses(
+      query.rules,
+      contact,
+      slug
+    );
+    res.attachment(exportName).send(exportData);
+    return res;
   }
 
   @Post("/:slug/responses")

--- a/src/api/data/CalloutResponseData/interface.ts
+++ b/src/api/data/CalloutResponseData/interface.ts
@@ -48,6 +48,13 @@ export class GetCalloutResponsesQuery extends GetPaginatedQuery {
   sort?: string;
 }
 
+export class ExportCalloutResponsesQuery {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GetPaginatedRuleGroup)
+  rules?: GetPaginatedRuleGroup;
+}
+
 export interface GetCalloutResponseData {
   id: string;
   number: number;

--- a/src/api/data/PaginatedData/index.ts
+++ b/src/api/data/PaginatedData/index.ts
@@ -294,7 +294,11 @@ export async function fetchPaginated<Entity, Field extends string>(
   try {
     const ruleGroup = query.rules && validateRuleGroup(filters, query.rules);
 
-    const qb = createQueryBuilder(entity, "item").offset(offset).limit(limit);
+    const qb = createQueryBuilder(entity, "item").offset(offset);
+
+    if (limit !== -1) {
+      qb.limit(limit);
+    }
 
     if (ruleGroup) {
       qb.where(...buildWhere(ruleGroup, contact, fieldHandlers, "item."));

--- a/src/apps/tools/apps/polls/app.ts
+++ b/src/apps/tools/apps/polls/app.ts
@@ -200,6 +200,8 @@ app.post(
                     EmailAddress: response.guestEmail
                   }),
               IsMember: !!response.contact,
+              Number: response.number,
+              Bucket: response.bucket,
               ...convertAnswers(callout, response.answers)
             };
           });


### PR DESCRIPTION
New endpoint to export all or a filtered subset of a callout's responses.

### New endpoints
* `GET /callout/:slug/responses.csv`: Download a callout's responses as a CSV
  This endpoint accepts the same `rules` query parameter as paginated endpoints to filter for a subset of responses