### PR TITLE
feat: new deployment strategy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: ["master", "dev", "release"]
+    branches: ["master", "dev"]
 
 jobs:
   init:
@@ -18,9 +18,6 @@ jobs:
               ;;
             refs/heads/dev)
               echo "stage=dev" >> $GITHUB_OUTPUT
-              ;;
-            refs/heads/release)
-              echo "stage=release" >> $GITHUB_OUTPUT
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - "feat/*"
+      - feat/*
 
 jobs:
   check:
@@ -14,12 +14,12 @@ jobs:
     needs: [check]
 
     outputs:
-      version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+      version: ${{ fromJSON(steps.app_meta.outputs.json).labels['org.opencontainers.image.version'] }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - id: meta
+      - id: app_meta
         uses: docker/metadata-action@v4
         with:
           flavor: |
@@ -27,8 +27,21 @@ jobs:
           images: |
             ${{ secrets.DOCKER_ORGANISATION }}/beabee-test
           tags: |
+            type=ref,event=tag
             type=ref,event=branch
-            release
+            test
+
+      - id: router_meta
+        uses: docker/metadata-action@v4
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ${{ secrets.DOCKER_ORGANISATION }}/beabee-router-test
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            test
 
       - uses: docker/login-action@v2
         with:
@@ -40,10 +53,20 @@ jobs:
           context: .
           target: app
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.app_meta.outputs.tags }}
+          labels: ${{ steps.app_meta.outputs.labels }}
           build-args: |
-            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            REVISION=${{ fromJSON(steps.app_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: router
+          push: true
+          tags: ${{ steps.router_meta.outputs.tags }}
+          labels: ${{ steps.router_meta.outputs.labels }}
+          build-args: |
+            REVISION=${{ fromJSON(steps.router_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
 
       - uses: docker/build-push-action@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,14 @@ jobs:
           repository: beabee-communityrm/test-deploy
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - run |
-        git config --global user.name "Deploy bot"
-        git config --global user.email "<>"
+      - run: |
+          git config --global user.name "Deploy bot"
+          git config --global user.email "<>"
 
-        echo -n ${{ needs.push.outputs.version }} > API_VERSION
+          echo -n ${{ needs.push.outputs.version }} > API_VERSION
 
-        ./update.sh
+          ./update.sh
 
-        git add docker-compose.yml
-        git commit -m "Deploy ${{ needs.push.outputs.version }}"
-        git push
+          git add docker-compose.yml
+          git commit -m "Deploy ${{ needs.push.outputs.version }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "feat/*"
+
+jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+
+  push:
+    runs-on: ubuntu-latest
+    needs: [check]
+
+    outputs:
+      version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          flavour: |
+            latest=false
+          images: |
+            ${{ secrets.DOCKER_ORGANISATION }}/beabee-test
+          tags: |
+            type=ref,event=tag
+            release
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: app
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+
+      - uses: docker/build-push-action@v4
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [push]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: beabee-communityrm/test-deploy
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - run |
+        git config --global user.name "Deploy bot"
+        git config --global user.email "<>"
+
+        echo -n ${{ needs.push.outputs.version }} > API_VERSION
+
+        ./update.sh
+
+        git add docker-compose.yml
+        git commit -m "Deploy ${{ needs.push.outputs.version }}"
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           images: |
             ${{ secrets.DOCKER_ORGANISATION }}/beabee-test
           tags: |
-            type=ref,event=tag
+            type=ref,event=branch
             release
 
       - uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v4
         with:
-          flavour: |
+          flavor: |
             latest=false
           images: |
             ${{ secrets.DOCKER_ORGANISATION }}/beabee-test
@@ -63,7 +63,7 @@ jobs:
           echo -n ${{ needs.push.outputs.version }} > API_VERSION
           ./update.sh
 
-          git add docker-compose.yml
+          git add API_VERSION docker-compose.yml
           if ! git diff --quiet --cached; then
             git commit -m "Deploy ${{ needs.push.outputs.version }}"
             git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - feat/*
+    tags:
+      - v*
 
 jobs:
   check:
@@ -25,11 +25,10 @@ jobs:
           flavor: |
             latest=false
           images: |
-            ${{ secrets.DOCKER_ORGANISATION }}/beabee-test
+            ${{ secrets.DOCKER_ORGANISATION }}/beabee
           tags: |
             type=ref,event=tag
-            type=ref,event=branch
-            test
+            release
 
       - id: router_meta
         uses: docker/metadata-action@v4
@@ -37,11 +36,10 @@ jobs:
           flavor: |
             latest=false
           images: |
-            ${{ secrets.DOCKER_ORGANISATION }}/beabee-router-test
+            ${{ secrets.DOCKER_ORGANISATION }}/beabee-router
           tags: |
             type=ref,event=tag
-            type=ref,event=branch
-            test
+            release
 
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,10 @@ jobs:
           git config --global user.email "<>"
 
           echo -n ${{ needs.push.outputs.version }} > API_VERSION
-
           ./update.sh
 
           git add docker-compose.yml
-          git commit -m "Deploy ${{ needs.push.outputs.version }}"
-          git push
+          if ! git diff --quiet --cached; then
+            git commit -m "Deploy ${{ needs.push.outputs.version }}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ steps.app_meta.outputs.tags }}
           labels: ${{ steps.app_meta.outputs.labels }}
           build-args: |
-            REVISION=${{ fromJSON(steps.app_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            REVISION=${{ github.sha }}
 
       - uses: docker/build-push-action@v4
         with:
@@ -64,9 +64,7 @@ jobs:
           tags: ${{ steps.router_meta.outputs.tags }}
           labels: ${{ steps.router_meta.outputs.labels }}
           build-args: |
-            REVISION=${{ fromJSON(steps.router_meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-
-      - uses: docker/build-push-action@v4
+            REVISION=${{ github.sha }}
 
   deploy:
     runs-on: ubuntu-latest
@@ -86,6 +84,6 @@ jobs:
 
           git add API_VERSION docker-compose.yml
           if ! git diff --quiet --cached; then
-            git commit -m "Deploy ${{ needs.push.outputs.version }}"
+            git commit -m "Deploy API ${{ needs.push.outputs.version }}"
             git push
           fi


### PR DESCRIPTION
This PR adds version tagging to Docker images. Any Git tags which match `v*` will now create an equivalent tag in Docker, the `release` Docker tag will continue to be updated.

It also triggers hive deployment by pushing an updated docker-compose.yml file (with latest tags) to a repo, which our Portainer instance polls then updates the stack. This is currently being tested (hence the repo is called test-deploy)