### PR TITLE
chore: more intuitive contact sorting

### DIFF
--- a/src/api/data/ContactData/index.ts
+++ b/src/api/data/ContactData/index.ts
@@ -244,7 +244,7 @@ export async function fetchPaginatedContacts(
               "COALESCE(mp.dateExpires, '-infinity'::timestamp)",
               "membershipExpires"
             )
-            .orderBy(`"${query.sort}"`, query.order || "ASC", "NULLS LAST");
+            .orderBy(query.sort, query.order || "ASC", "NULLS LAST");
           break;
 
         // Always put empty first/last names at the bottom

--- a/src/api/data/PaginatedData/index.ts
+++ b/src/api/data/PaginatedData/index.ts
@@ -311,7 +311,7 @@ export async function fetchPaginated<Entity, Field extends string>(
     }
 
     if (query.sort) {
-      qb.orderBy({ [`item."${query.sort}"`]: query.order || "ASC" });
+      qb.orderBy(`item."${query.sort}"`, query.order || "ASC", "NULLS LAST");
     }
 
     queryCallback?.(qb, "item.");


### PR DESCRIPTION
- Always sort null values to the bottom (could be configurable in the future?).
- Clean up sort specific contact logic