### PR TITLE
fix: update callout always trying to set formSchema

### DIFF
--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -101,7 +101,9 @@ export class CalloutController {
     await getRepository(Callout).update(slug, {
       ...data,
       // Force the correct type as otherwise this errors, not sure why
-      formSchema: data.formSchema as QueryDeepPartialEntity<CalloutFormSchema>
+      ...(data.formSchema && {
+        formSchema: data.formSchema as QueryDeepPartialEntity<CalloutFormSchema>
+      })
     });
     try {
       return await fetchCallout({ slug: newSlug }, {}, contact);


### PR DESCRIPTION
It should only try to set `formSchema` if it exists in the request data