### PR TITLE
chore: enable gzip globally

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,3 @@
-gzip on;
-gzip_vary on;
-
 server {
   listen 80;
   listen [::]:80;
@@ -19,7 +16,6 @@ server {
 
   location /static {
       root /opt/membership-system/built/;
-      gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
   }
 
   location ~ ^/api/(.*)$ {


### PR DESCRIPTION
Remove gzip from here in favour of it being enabled in the main router, see https://github.com/beabee-communityrm/beabee-router/pull/10