### PR TITLE
Feat: 🔧 Reset MFA via email

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -29,6 +29,7 @@ import { SegmentController } from "./controllers/SegmentController";
 import { SignupController } from "./controllers/SignupController";
 import { StatsController } from "./controllers/StatsController";
 import { ResetPasswordController } from "./controllers/ResetPasswordController";
+import { ResetDeviceController } from "./controllers/ResetDeviceController";
 import { UploadController } from "./controllers/UploadController";
 
 import * as db from "@core/database";
@@ -86,6 +87,7 @@ db.connect().then(() => {
       SignupController,
       StatsController,
       ResetPasswordController,
+      ResetDeviceController,
       UploadController
     ],
     currentUserChecker,

--- a/src/api/controllers/ResetDeviceController.ts
+++ b/src/api/controllers/ResetDeviceController.ts
@@ -1,0 +1,79 @@
+import { Request } from "express";
+import {
+  Body,
+  JsonController,
+  NotFoundError,
+  OnUndefined,
+  Params,
+  Post,
+  Put,
+  Req
+} from "routing-controllers";
+import { getRepository } from "typeorm";
+
+import ContactsService from "@core/services/ContactsService";
+import EmailService from "@core/services/EmailService";
+import AuthService from "@core/services/AuthService";
+import ContactMfaService from "@core/services/ContactMfaService";
+
+import ResetPasswordFlow from "@models/ResetPasswordFlow";
+
+import { login } from "@api/utils";
+import { UUIDParam } from "@api/data";
+import {
+  CreateResetDeviceData,
+  UpdateResetDeviceData
+} from "@api/data/ResetDeviceData";
+import UnauthorizedError from "@api/errors/UnauthorizedError";
+
+@JsonController("/reset-device")
+export class ResetDeviceController {
+  @OnUndefined(204)
+  @Post()
+  async create(@Body() data: CreateResetDeviceData): Promise<void> {
+    const contact = await ContactsService.findOne({ email: data.email });
+    if (contact) {
+      const rpFlow = await getRepository(ResetPasswordFlow).save({ contact });
+      await EmailService.sendTemplateToContact("reset-device", contact, {
+        rpLink: data.resetUrl + "/" + rpFlow.id
+      });
+    }
+  }
+
+  @OnUndefined(204)
+  @Put("/:id")
+  async complete(
+    @Req() req: Request,
+    @Params() { id }: UUIDParam,
+    @Body() data: UpdateResetDeviceData
+  ): Promise<void> {
+    const rpFlow = await getRepository(ResetPasswordFlow).findOne({
+      where: { id },
+      relations: ["contact"]
+    });
+    if (rpFlow) {
+      // Validate password
+      const isValid = await AuthService.isValidPassword(
+        rpFlow.contact.password,
+        data.password
+      );
+
+      if (!isValid) {
+        // TODO: Increment tries
+        // TODO: Error code
+        throw new UnauthorizedError();
+      }
+
+      // Disable MFA
+      await ContactMfaService.delete(rpFlow.contact);
+
+      // Stop reset flow
+      // TODO: Separate reset flow from MFA?
+      await getRepository(ResetPasswordFlow).delete(id);
+
+      await login(req, rpFlow.contact);
+    } else {
+      throw new NotFoundError();
+    }
+  }
+}

--- a/src/api/data/ResetDeviceData.ts
+++ b/src/api/data/ResetDeviceData.ts
@@ -1,0 +1,16 @@
+import { IsEmail, Validate } from "class-validator";
+import IsPassword from "@api/validators/IsPassword";
+import IsUrl from "@api/validators/IsUrl";
+
+export class CreateResetDeviceData {
+  @IsEmail()
+  email!: string;
+
+  @IsUrl()
+  resetUrl!: string;
+}
+
+export class UpdateResetDeviceData {
+  @Validate(IsPassword)
+  password!: string;
+}

--- a/src/apps/tools/apps/emails/app.ts
+++ b/src/apps/tools/apps/emails/app.ts
@@ -39,6 +39,7 @@ export function schemaToEmail(data: EmailSchema): Email {
 const assignableSystemEmails = {
   welcome: "Welcome",
   "reset-password": "Reset password",
+  "reset-device": "Reset device",
   "cancelled-contribution": "Cancelled contribution",
   "cancelled-contribution-no-survey": "Cancelled contribution - no survey",
   "confirm-email": "Confirm email",

--- a/src/core/data/email/reset-device_de.yfm
+++ b/src/core/data/email/reset-device_de.yfm
@@ -1,0 +1,17 @@
+---
+subject: Anfrage zum Zurücksetzen Ihres Multi-Faktor-Authentifizierungsgeräts
+---
+
+<p>Sehr geehrte*r *|FNAME|* *|LNAME|*,</p>
+
+<p>wir haben eine Anfrage zum Zurücksetzen Ihres Multi-Faktor-Authentifizierungsgeräts erhalten. Um die Zurücksetzung zu
+    bestätigen und ein neues Gerät einzurichten, klicken Sie bitte auf den folgenden Link:</p>
+
+<p><a href="*|RPLINK|*"><strong>Multi-Faktor-Authentifizierung zurücksetzen</strong></a></p>
+
+<p>Wenn Sie diese Zurücksetzung nicht angefordert haben oder es sich um einen Fehler handelt, können Sie diese Nachricht
+    ignorieren oder uns für weitere Unterstützung kontaktieren.</p>
+
+<p>Bitte beachten Sie, dass der obige Link aus Sicherheitsgründen nur für eine begrenzte Zeit gültig ist.</p>
+
+<p>Mit freundlichen Grüßen</p>

--- a/src/core/data/email/reset-device_de@informal.yfm
+++ b/src/core/data/email/reset-device_de@informal.yfm
@@ -1,0 +1,17 @@
+---
+subject: Zurücksetzen deiner Multi-Faktor-Authentifizierung
+---
+
+<p>Hallo *|FNAME|* *|LNAME|*,</p>
+
+<p>du hast eine Zurücksetzung deiner Multi-Faktor-Authentifizierung beantragt. Um dein Gerät zurückzusetzen und ein
+    neues einzurichten, klicke einfach auf den folgenden Link:</p>
+
+<p><a href="*|RPLINK|*"><strong>Jetzt MFA-Gerät zurücksetzen</strong></a></p>
+
+<p>Falls du diese Zurücksetzung nicht angefordert hast oder es sich um einen Irrtum handelt, ignoriere diese E-Mail
+    einfach oder melde dich bei uns, falls du Unterstützung benötigst.</p>
+
+<p>Der Link ist nur kurzzeitig gültig, also zögere nicht zu lange.</p>
+
+<p>Viele Grüße</p>

--- a/src/core/data/email/reset-device_en.yfm
+++ b/src/core/data/email/reset-device_en.yfm
@@ -1,0 +1,15 @@
+---
+subject: Resetting Your Multi-Factor Authentication
+---
+
+<p>Hello *|FNAME|* *|LNAME|*,</p>
+
+<p>You've requested a reset of your multi-factor authentication. To reset your device and set up a new one, just click on the following link:</p>
+
+<p><a href="*|RPLINK|*"><strong>Reset MFA Device Now</strong></a></p>
+
+<p>If you didn't request this reset or if it was a mistake, please simply ignore this email or get in touch with us if you need support.</p>
+
+<p>The link is only valid for a short period, so don't delay too long.</p>
+
+<p>Best wishes</p>

--- a/src/core/lib/passport.ts
+++ b/src/core/lib/passport.ts
@@ -11,7 +11,7 @@ import { generatePassword, hashPassword } from "@core/utils/auth";
 import OptionsService from "@core/services/OptionsService";
 import ContactsService from "@core/services/ContactsService";
 import ContactMfaService from "@core/services/ContactMfaService";
-import { ContactMfaSecure } from "@models/ContactMfa";
+import authService from "@core/services/AuthService";
 
 import { LoginData } from "@api/controllers/AuthController";
 import {
@@ -22,6 +22,7 @@ import {
 import { UnauthorizedError } from "@api/errors/UnauthorizedError";
 
 import Contact from "@models/Contact";
+import { ContactMfaSecure } from "@models/ContactMfa";
 
 // Add support for local authentication in Passport.js
 passport.use(
@@ -62,8 +63,7 @@ passport.use(
           contact.password.iterations
         );
 
-        // Check if password hash matches
-        if (hash === contact.password.hash) {
+        if (await authService.isValidPassword(contact.password, password)) {
           // Reset tries
           if (tries > 0) {
             await ContactsService.updateContact(contact, {

--- a/src/core/services/AuthService.ts
+++ b/src/core/services/AuthService.ts
@@ -6,6 +6,11 @@ import ContactsService from "./ContactsService";
 
 import ApiKey from "@models/ApiKey";
 import Contact from "@models/Contact";
+import Password from "@models/Password";
+
+import { LoginData } from "@api/controllers/AuthController";
+
+import { hashPassword } from "@core/utils/auth";
 
 async function isValidApiKey(key: string): Promise<boolean> {
   const [_, secret] = key.split("_");
@@ -34,6 +39,25 @@ class AuthService {
 
     // Otherwise use logged in user
     return request.user;
+  }
+
+  /**
+   * Check if password hash matches the raw password.
+   * @param passwordData Password data from database
+   * @param passwordRaw Raw password
+   * @returns Whether the password is valid or not
+   */
+  async isValidPassword(
+    passwordData: Password,
+    passwordRaw: LoginData["password"]
+  ): Promise<boolean> {
+    const hash = await hashPassword(
+      passwordRaw,
+      passwordData.salt,
+      passwordData.iterations
+    );
+    // Check if password hash matches
+    return hash === passwordData.hash;
   }
 }
 

--- a/src/core/services/EmailService.ts
+++ b/src/core/services/EmailService.ts
@@ -82,6 +82,9 @@ const contactEmailTemplates = {
   "reset-password": (_: Contact, params: { rpLink: string }) => ({
     RPLINK: params.rpLink
   }),
+  "reset-device": (_: Contact, params: { rpLink: string }) => ({
+    RPLINK: params.rpLink
+  }),
   "cancelled-contribution": (contact: Contact) => ({
     EXPIRES: contact.membership?.dateExpires
       ? moment.utc(contact.membership.dateExpires).format("dddd Do MMMM")


### PR DESCRIPTION
## Overview
This pull request introduces the backend functionality for the "Reset MFA via Email" feature. It aims to provide users with the ability to reset their multi-factor authentication (MFA) device via a secure email link, enhancing the user experience and security.

## What has been done
- **Email Templates**: Added multilingual support for the reset MFA feature with templates in German (formal and informal) and English.
- **Reset Device Controller**: Created a new controller to handle MFA device reset requests. This includes generating and sending the secure email link to the user.
- **Auth Service Refactoring**: Introduced a `isValidPassword` method within the `AuthService` to reduce code duplication and streamline password validation checks across the application.

