### PR TITLE
fix: round protation time to nearest second

### DIFF
--- a/src/core/utils/payment/stripe.ts
+++ b/src/core/utils/payment/stripe.ts
@@ -41,10 +41,11 @@ async function calculateProrationParams(
   );
   // Calculate exact number of seconds to remove (rather than just "one month")
   // as this aligns with Stripe's calculations
-  const prorationTime =
+  const prorationTime = Math.floor(
     subscription.current_period_end -
-    (subscription.current_period_end - subscription.current_period_start) *
-      (monthsLeft / 12);
+      (subscription.current_period_end - subscription.current_period_start) *
+        (monthsLeft / 12)
+  );
 
   const invoice = await stripe.invoices.retrieveUpcoming({
     subscription: subscription.id,


### PR DESCRIPTION
Previous implementation assumed that all period lengths (end - start) would be divisible by 12 because they were made up of whole days, but this isn't necessarily true for manual contributions