### PR TITLE
fix: add NL and fallback to EN for emails

### DIFF
--- a/src/core/services/EmailService.ts
+++ b/src/core/services/EmailService.ts
@@ -320,9 +320,11 @@ class EmailService {
   }
 
   private getDefaultEmail(template: EmailTemplateId): Email | undefined {
-    return this.defaultEmails[OptionsService.getText("locale") as Locale]?.[
-      template
-    ];
+    const locale = OptionsService.getText("locale") as Locale;
+    return (
+      this.defaultEmails[locale]?.[template] ||
+      this.defaultEmails.en?.[template]
+    );
   }
 
   private convertContactToRecipient(

--- a/src/locales/current.ts
+++ b/src/locales/current.ts
@@ -7,7 +7,8 @@ import localeEn from "./en.json";
 const locales = {
   de: localeDe,
   "de@informal": localeDeInformal,
-  en: localeEn
+  en: localeEn,
+  nl: localeEn // CNR only
 } as const;
 
 export type Locale = keyof typeof locales;


### PR DESCRIPTION
We added NL with limited translations (for CNR mode), so just fallback to EN for emails and other translations