### PR TITLE
feat: upgrade TypeORM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,4 @@ BEABEE_COUNTRYCODE=en
 BEABEE_CURRENCYCODE=GBP
 BEABEE_CURRENCYSYMBOL=£
 
-TYPEORM_URL=postgres://membership_system:membership_system@db/membership_system
-TYPEORM_SYNCHRONIZE=false
+BEABEE_DATABASE_URL=postgres://membership_system:membership_system@db/membership_system

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN echo -n ${REVISION} > /opt/membership-system/built/revision.txt
 
 ENV NODE_ENV=production
 ENV NODE_OPTIONS=--enable-source-maps
-ENV TYPEORM_MIGRATIONS=built/migrations/*.js
-ENV TYPEORM_ENTITIES=built/models/*.js
 
 USER node
 CMD [ "node", "built/app" ]

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ docker compose up -d
 
 #### Generating database migrations
 
-Whenever you make changes to an object that is mapped into the database, you have to use `typeORM` and create a new migration file. Make sure the database container is running and then:
+Whenever you make changes to a database model, you need to create a migration
+file. TypeORM will automatically generate a migration file based on your schema
+changes
 
 ```
-docker compose run -u root app npm run typeorm migration:generate -- -n <MigrationName>
+docker compose start db
+docker compose run app npm run typeorm migration:generate src/migrations/MigrationName
 npm run build
 docker compose run app npm run typeorm migration:run
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ x-base-app: &base-app
     - .env
   environment:
     NODE_ENV: development
-    TYPEORM_MIGRATIONS_DIR: src/migrations/
 
 services:
   db:

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "slugify": "^1.6.6",
         "stripe": "^9.16.0",
         "tar-stream": "^3.1.6",
-        "typeorm": "^0.2.39",
+        "typeorm": "^0.3.17",
         "uuid": "^9.0.1",
         "winston": "^3.11.0",
         "yaml-front-matter": "^4.1.1"
@@ -2310,11 +2310,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
-    "node_modules/@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
@@ -3917,7 +3912,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -4642,7 +4638,6 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -10509,6 +10504,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12001,11 +11997,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -13344,52 +13335,60 @@
       "devOptional": true
     },
     "node_modules/typeorm": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.2.45.tgz",
-      "integrity": "sha512-c0rCO8VMJ3ER7JQ73xfk0zDnVv0WDjpsP6Q1m6CVKul7DB9iVdWLRjPzc8v2eaeBuomsbZ2+gTaYr8k1gm3bYA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "debug": "^4.3.1",
-        "dotenv": "^8.2.0",
-        "glob": "^7.1.6",
-        "js-yaml": "^4.0.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.1.0",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.0.1",
-        "zen-observable-ts": "^1.0.0"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "bin": {
-        "typeorm": "cli.js"
+        "typeorm": "cli.js",
+        "typeorm-ts-node-commonjs": "cli-ts-node-commonjs.js",
+        "typeorm-ts-node-esm": "cli-ts-node-esm.js"
+      },
+      "engines": {
+        "node": ">= 12.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/typeorm"
       },
       "peerDependencies": {
-        "@sap/hana-client": "^2.11.14",
-        "better-sqlite3": "^7.1.2",
+        "@google-cloud/spanner": "^5.18.0",
+        "@sap/hana-client": "^2.12.25",
+        "better-sqlite3": "^7.1.2 || ^8.0.0",
         "hdb-pool": "^0.1.6",
-        "ioredis": "^4.28.3",
-        "mongodb": "^3.6.0",
-        "mssql": "^6.3.1",
-        "mysql2": "^2.2.5",
+        "ioredis": "^5.0.4",
+        "mongodb": "^5.2.0",
+        "mssql": "^9.1.1",
+        "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
-        "redis": "^3.1.1",
+        "redis": "^3.1.1 || ^4.0.0",
         "sql.js": "^1.4.0",
-        "sqlite3": "^5.0.2",
+        "sqlite3": "^5.0.3",
+        "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0"
       },
       "peerDependenciesMeta": {
+        "@google-cloud/spanner": {
+          "optional": true
+        },
         "@sap/hana-client": {
           "optional": true
         },
@@ -13432,15 +13431,13 @@
         "sqlite3": {
           "optional": true
         },
+        "ts-node": {
+          "optional": true
+        },
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
       }
-    },
-    "node_modules/typeorm/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/typeorm/node_modules/base64-js": {
       "version": "1.5.1",
@@ -13460,15 +13457,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
@@ -13509,78 +13497,53 @@
         }
       }
     },
-    "node_modules/typeorm/node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/typeorm/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typeorm/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/typeorm/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/typeorm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/typeorm/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typeorm/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/typescript": {
       "version": "5.3.3",
@@ -14364,26 +14327,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -14489,20 +14432,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
-      "dependencies": {
-        "@types/zen-observable": "0.8.3",
-        "zen-observable": "0.8.15"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "slugify": "^1.6.6",
     "stripe": "^9.16.0",
     "tar-stream": "^3.1.6",
-    "typeorm": "^0.2.39",
+    "typeorm": "^0.3.17",
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "yaml-front-matter": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "check:prettier": "prettier -c .",
     "check:dependencies": "dpdm -T --no-warning --no-tree --exit-code circular:1 src/app.ts src/webhooks/app.ts src/api/app.ts",
     "fix:prettier": "prettier --write .",
-    "typeorm": "node --require module-alias/register node_modules/.bin/typeorm",
+    "typeorm": "node --require module-alias/register node_modules/.bin/typeorm -d ./built/core/database.js",
     "test": "jest --setupFiles dotenv/config"
   },
   "dependencies": {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -30,14 +30,13 @@ import { ResetPasswordController } from "./controllers/ResetPasswordController";
 import { ResetDeviceController } from "./controllers/ResetDeviceController";
 import { UploadController } from "./controllers/UploadController";
 
-import * as db from "@core/database";
 import {
   log as mainLogger,
   requestErrorLogger,
   requestLogger
 } from "@core/logging";
 import sessions from "@core/sessions";
-import startServer from "@core/server";
+import { initApp, startServer } from "@core/server";
 
 import AuthService from "@core/services/AuthService";
 
@@ -65,7 +64,7 @@ app.use(cors({ origin: config.trustedOrigins }));
 
 app.use(cookie());
 
-db.connect().then(() => {
+initApp().then(() => {
   sessions(app);
 
   useExpressServer(app, {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -64,69 +64,73 @@ app.use(cors({ origin: config.trustedOrigins }));
 
 app.use(cookie());
 
-initApp().then(() => {
-  sessions(app);
+initApp()
+  .then(() => {
+    sessions(app);
 
-  useExpressServer(app, {
-    routePrefix: "/1.0",
-    controllers: [
-      ApiKeyController,
-      AuthController,
-      CalloutController,
-      CalloutResponseController,
-      CalloutResponseCommentController,
-      ContentController,
-      EmailController,
-      ContactController,
-      NoticeController,
-      PaymentController,
-      SegmentController,
-      SignupController,
-      StatsController,
-      ResetPasswordController,
-      ResetDeviceController,
-      UploadController
-    ],
-    currentUserChecker,
-    authorizationChecker,
-    validation: {
-      forbidNonWhitelisted: true,
-      forbidUnknownValues: true,
-      whitelist: true,
-      validationError: {
-        target: false,
-        value: false
+    useExpressServer(app, {
+      routePrefix: "/1.0",
+      controllers: [
+        ApiKeyController,
+        AuthController,
+        CalloutController,
+        CalloutResponseController,
+        CalloutResponseCommentController,
+        ContentController,
+        EmailController,
+        ContactController,
+        NoticeController,
+        PaymentController,
+        SegmentController,
+        SignupController,
+        StatsController,
+        ResetPasswordController,
+        ResetDeviceController,
+        UploadController
+      ],
+      currentUserChecker,
+      authorizationChecker,
+      validation: {
+        forbidNonWhitelisted: true,
+        forbidUnknownValues: true,
+        whitelist: true,
+        validationError: {
+          target: false,
+          value: false
+        }
+      },
+      defaults: {
+        paramOptions: {
+          required: true
+        }
+      },
+      defaultErrorHandler: false
+    });
+
+    app.use((req, res) => {
+      if (!res.headersSent) {
+        throw new NotFoundError();
       }
-    },
-    defaults: {
-      paramOptions: {
-        required: true
+    });
+
+    const log = mainLogger.child({ app: "response" });
+
+    app.use(function (error, req, res, next) {
+      if (error instanceof HttpError && error.httpCode < 500) {
+        res.status(error.httpCode).send(error);
+        if (error.httpCode === 400) {
+          log.notice(error);
+        }
+      } else {
+        log.error("Unhandled error: ", error);
+        res.status(500).send(new InternalServerError("Unhandled error"));
       }
-    },
-    defaultErrorHandler: false
+    } as ErrorRequestHandler);
+
+    app.use(requestErrorLogger);
+
+    startServer(app);
+  })
+  .catch((err) => {
+    mainLogger.error("Error during initialization", err);
   });
-
-  app.use((req, res) => {
-    if (!res.headersSent) {
-      throw new NotFoundError();
-    }
-  });
-
-  const log = mainLogger.child({ app: "response" });
-
-  app.use(function (error, req, res, next) {
-    if (error instanceof HttpError && error.httpCode < 500) {
-      res.status(error.httpCode).send(error);
-      if (error.httpCode === 400) {
-        log.notice(error);
-      }
-    } else {
-      log.error("Unhandled error: ", error);
-      res.status(500).send(new InternalServerError("Unhandled error"));
-    }
-  } as ErrorRequestHandler);
-
-  app.use(requestErrorLogger);
-
-  startServer(app);
-});

--- a/src/api/controllers/ApiKeyController.ts
+++ b/src/api/controllers/ApiKeyController.ts
@@ -11,7 +11,12 @@ import {
   Delete,
   Param
 } from "routing-controllers";
-import { getRepository } from "typeorm";
+
+import { getRepository } from "@core/database";
+import { generateApiKey } from "@core/utils/auth";
+
+import ApiKey from "@models/ApiKey";
+import Contact from "@models/Contact";
 
 import {
   CreateApiKeyData,
@@ -20,9 +25,6 @@ import {
   fetchPaginatedApiKeys
 } from "@api/data/ApiKeyData";
 import { Paginated } from "@api/data/PaginatedData";
-import { generateApiKey } from "@core/utils/auth";
-import ApiKey from "@models/ApiKey";
-import Contact from "@models/Contact";
 
 @JsonController("/api-key")
 @Authorized("admin")

--- a/src/api/controllers/AuthController.ts
+++ b/src/api/controllers/AuthController.ts
@@ -13,10 +13,10 @@ import {
   Req,
   Res
 } from "routing-controllers";
-import { getRepository } from "typeorm";
 
 import { UnauthorizedError } from "../errors/UnauthorizedError";
 
+import { getRepository } from "@core/database";
 import passport from "@core/lib/passport";
 
 import ContactsService from "@core/services/ContactsService";
@@ -107,12 +107,12 @@ export class AuthController {
     let contact: Contact | undefined;
     if (RoleTypes.indexOf(id as RoleType) > -1) {
       const role = await getRepository(ContactRole).findOne({
-        where: { type: id },
+        where: { type: id as RoleType },
         relations: ["contact"]
       });
       contact = role?.contact;
     } else if (isUUID(id, "4")) {
-      contact = await ContactsService.findOne(id);
+      contact = await ContactsService.findOneBy({ id });
     }
 
     if (contact) {

--- a/src/api/controllers/AuthController.ts
+++ b/src/api/controllers/AuthController.ts
@@ -108,7 +108,7 @@ export class AuthController {
     if (RoleTypes.indexOf(id as RoleType) > -1) {
       const role = await getRepository(ContactRole).findOne({
         where: { type: id as RoleType },
-        relations: ["contact"]
+        relations: { contact: true }
       });
       contact = role?.contact;
     } else if (isUUID(id, "4")) {

--- a/src/api/controllers/CalloutController.ts
+++ b/src/api/controllers/CalloutController.ts
@@ -17,12 +17,12 @@ import {
   Res
 } from "routing-controllers";
 import slugify from "slugify";
-import { getRepository } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
 import CalloutsService from "@core/services/CalloutsService";
 import OptionsService from "@core/services/OptionsService";
 
+import { getRepository } from "@core/database";
 import { isDuplicateIndex } from "@core/utils";
 
 import Contact from "@models/Contact";
@@ -147,7 +147,7 @@ export class CalloutController {
     @Param("slug") slug: string,
     @QueryParams() query: GetCalloutResponsesQuery
   ): Promise<Paginated<GetCalloutResponseData>> {
-    const callout = await getRepository(Callout).findOne(slug);
+    const callout = await getRepository(Callout).findOneBy({ slug });
     if (!callout) {
       throw new NotFoundError();
     }
@@ -161,7 +161,7 @@ export class CalloutController {
     @QueryParams() query: GetExportQuery,
     @Res() res: Response
   ): Promise<Response> {
-    const callout = await getRepository(Callout).findOne(slug);
+    const callout = await getRepository(Callout).findOneBy({ slug });
     if (!callout) {
       throw new NotFoundError();
     }
@@ -180,7 +180,7 @@ export class CalloutController {
     @Param("slug") slug: string,
     @QueryParams() query: GetCalloutResponsesQuery
   ): Promise<Paginated<GetCalloutResponseMapData>> {
-    const callout = await getRepository(Callout).findOne(slug);
+    const callout = await getRepository(Callout).findOneBy({ slug });
     if (!callout) {
       throw new NotFoundError();
     }
@@ -194,7 +194,7 @@ export class CalloutController {
     @Param("slug") slug: string,
     @Body() data: CreateCalloutResponseData
   ): Promise<void> {
-    const callout = await getRepository(Callout).findOne(slug);
+    const callout = await getRepository(Callout).findOneBy({ slug });
     if (!callout) {
       throw new NotFoundError();
     }
@@ -255,8 +255,8 @@ export class CalloutController {
       data
     );
 
-    const tag = await getRepository(CalloutTag).findOne(tagId);
-    return tag && convertTagToData(tag);
+    const tag = await getRepository(CalloutTag).findOneBy({ id: tagId });
+    return tag ? convertTagToData(tag) : undefined;
   }
 
   @Authorized("admin")

--- a/src/api/controllers/CalloutResponseCommentController.ts
+++ b/src/api/controllers/CalloutResponseCommentController.ts
@@ -60,7 +60,7 @@ export class CalloutResponseCommentController {
   ): Promise<GetCalloutResponseCommentData | undefined> {
     const comment = await getRepository(CalloutResponseComment).findOne({
       where: { id: id },
-      relations: ["contact"]
+      relations: { contact: true }
     });
     if (comment) {
       return convertCommentToData(comment);

--- a/src/api/controllers/CalloutResponseCommentController.ts
+++ b/src/api/controllers/CalloutResponseCommentController.ts
@@ -11,7 +11,7 @@ import {
 } from "@api/data/CalloutResponseCommentData/interface";
 import PartialBody from "@api/decorators/PartialBody";
 import { Paginated } from "@beabee/beabee-common";
-import CalloutResponse from "@models/CalloutResponse";
+import { getRepository } from "@core/database";
 import CalloutResponseComment from "@models/CalloutResponseComment";
 import Contact from "@models/Contact";
 import {
@@ -28,7 +28,6 @@ import {
   Post,
   QueryParams
 } from "routing-controllers";
-import { getRepository } from "typeorm";
 
 @JsonController("/callout-response-comments")
 @Authorized("admin")

--- a/src/api/controllers/ContactController.ts
+++ b/src/api/controllers/ContactController.ts
@@ -22,7 +22,6 @@ import {
   QueryParams,
   Res
 } from "routing-controllers";
-import { getRepository } from "typeorm";
 
 import { PaymentFlowParams } from "@core/providers/payment-flow";
 
@@ -33,6 +32,7 @@ import PaymentFlowService from "@core/services/PaymentFlowService";
 import PaymentService from "@core/services/PaymentService";
 import ContactMfaService from "@core/services/ContactMfaService";
 
+import { getRepository } from "@core/database";
 import { ContributionInfo } from "@core/utils";
 import { generatePassword } from "@core/utils/auth";
 
@@ -105,7 +105,7 @@ function TargetUser() {
         uuid.id = id;
         await validateOrReject(uuid);
 
-        const target = await ContactsService.findOne(id);
+        const target = await ContactsService.findOneBy({ id });
         if (target) {
           return target;
         } else {
@@ -196,7 +196,7 @@ export class ContactController {
   ): Promise<GetContactData> {
     if (query.with?.includes(GetContactWith.Profile)) {
       target.profile = await getRepository(ContactProfile).findOneOrFail({
-        contact: target
+        where: { contactId: target.id }
       });
     }
     const data = convertContactToData(target, {

--- a/src/api/controllers/ContentController.ts
+++ b/src/api/controllers/ContentController.ts
@@ -6,9 +6,11 @@ import {
   Param,
   Patch
 } from "routing-controllers";
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
 import OptionsService, { OptionKey } from "@core/services/OptionsService";
+
+import { getRepository } from "@core/database";
 import { getEmailFooter } from "@core/utils/email";
 
 import Content, { ContentId } from "@models/Content";
@@ -86,7 +88,7 @@ const contentReadOnly: ContentMap<[() => any]> = {
 export class ContentController {
   @Get("/:id(*)")
   async get(@Param("id") id: ContentId): Promise<object | undefined> {
-    const content = await getRepository(Content).findOne(id);
+    const content = await getRepository(Content).findOneBy({ id });
 
     if (content) {
       const optsData = contentOptions[id]?.map(

--- a/src/api/controllers/ContentController.ts
+++ b/src/api/controllers/ContentController.ts
@@ -6,11 +6,10 @@ import {
   Param,
   Patch
 } from "routing-controllers";
-import { createQueryBuilder } from "typeorm";
 
 import OptionsService, { OptionKey } from "@core/services/OptionsService";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { getEmailFooter } from "@core/utils/email";
 
 import Content, { ContentId } from "@models/Content";

--- a/src/api/controllers/NoticeController.ts
+++ b/src/api/controllers/NoticeController.ts
@@ -13,7 +13,8 @@ import {
   Post,
   QueryParams
 } from "routing-controllers";
-import { getRepository } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import Contact from "@models/Contact";
 import Notice from "@models/Notice";
@@ -73,7 +74,7 @@ export class NoticeController {
     @CurrentUser() contact: Contact,
     @Params() { id }: UUIDParam
   ): Promise<GetNoticeData | undefined> {
-    const notice = await getRepository(Notice).findOne(id);
+    const notice = await getRepository(Notice).findOneBy({ id });
     if (notice && (notice.active || contact.hasRole("admin"))) {
       return this.noticeToData(notice);
     }

--- a/src/api/controllers/SegmentController.ts
+++ b/src/api/controllers/SegmentController.ts
@@ -11,7 +11,8 @@ import {
   Post,
   QueryParams
 } from "routing-controllers";
-import { getRepository } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import { UUIDParam } from "@api/data";
 import {
@@ -74,7 +75,7 @@ export class SegmentController {
     @Params() { id }: UUIDParam,
     @QueryParams() query: GetSegmentQuery
   ): Promise<GetSegmentData | undefined> {
-    const segment = await getRepository(Segment).findOne(id);
+    const segment = await getRepository(Segment).findOneBy({ id });
     if (segment) {
       return convertSegmentToData(segment, query);
     }
@@ -108,7 +109,7 @@ export class SegmentController {
     @Params() { id }: UUIDParam,
     @QueryParams() query: GetContactsQuery
   ): Promise<Paginated<GetContactData> | undefined> {
-    const segment = await getRepository(Segment).findOne(id);
+    const segment = await getRepository(Segment).findOneBy({ id });
     if (segment) {
       return await fetchPaginatedContacts(
         {

--- a/src/api/controllers/SignupController.ts
+++ b/src/api/controllers/SignupController.ts
@@ -7,8 +7,8 @@ import {
   Post,
   Req
 } from "routing-controllers";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { generatePassword } from "@core/utils/auth";
 
 import PaymentFlowService from "@core/services/PaymentFlowService";
@@ -78,7 +78,9 @@ export class SignupController {
     @Req() req: Request,
     @Body() { joinFlowId }: SignupConfirmEmailParam
   ): Promise<void> {
-    const joinFlow = await getRepository(JoinFlow).findOne(joinFlowId);
+    const joinFlow = await getRepository(JoinFlow).findOneBy({
+      id: joinFlowId
+    });
     if (!joinFlow) {
       throw new NotFoundError();
     }

--- a/src/api/controllers/StatsController.ts
+++ b/src/api/controllers/StatsController.ts
@@ -9,7 +9,7 @@ import {
   JsonController,
   QueryParams
 } from "routing-controllers";
-import { createQueryBuilder } from "typeorm";
+import { createQueryBuilder } from "@core/database";
 
 class GetStatsQuery {
   @Type(() => Date)

--- a/src/api/controllers/UploadController.ts
+++ b/src/api/controllers/UploadController.ts
@@ -11,7 +11,9 @@ import {
   Post,
   Req
 } from "routing-controllers";
-import { MoreThan, getRepository } from "typeorm";
+import { MoreThan } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import Contact from "@models/Contact";
 import UploadFlow from "@models/UploadFlow";

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -1,8 +1,8 @@
 import { calloutFilters, ItemStatus } from "@beabee/beabee-common";
 import { BadRequestError, UnauthorizedError } from "routing-controllers";
-import { createQueryBuilder, FindOptionsWhere } from "typeorm";
+import { FindOptionsWhere } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 
 import {
   fetchPaginated,

--- a/src/api/data/CalloutData/index.ts
+++ b/src/api/data/CalloutData/index.ts
@@ -1,6 +1,8 @@
 import { calloutFilters, ItemStatus } from "@beabee/beabee-common";
 import { BadRequestError, UnauthorizedError } from "routing-controllers";
-import { createQueryBuilder, FindConditions, getRepository } from "typeorm";
+import { createQueryBuilder, FindOptionsWhere } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import {
   fetchPaginated,
@@ -64,7 +66,7 @@ export function convertCalloutToData(
 }
 
 export async function fetchCallout(
-  where: FindConditions<Callout>,
+  where: FindOptionsWhere<Callout>,
   query: GetCalloutQuery,
   contact: Contact | undefined
 ): Promise<GetCalloutData | undefined> {
@@ -82,12 +84,14 @@ export async function fetchCallout(
 
   if (query.with?.includes(GetCalloutWith.HasAnswered) && contact) {
     callout.hasAnswered =
-      (await getRepository(CalloutResponse).count({ callout, contact })) > 0;
+      (await getRepository(CalloutResponse).count({
+        where: { calloutSlug: callout.slug, contactId: contact.id }
+      })) > 0;
   }
 
   if (query.with?.includes(GetCalloutWith.ResponseCount)) {
     callout.responseCount = await getRepository(CalloutResponse).count({
-      callout
+      where: { calloutSlug: callout.slug }
     });
   }
 

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -15,8 +15,10 @@ import {
 import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns";
 import { NotFoundError } from "routing-controllers";
-import { In, createQueryBuilder, getRepository } from "typeorm";
+import { In, createQueryBuilder } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+
+import { getRepository } from "@core/database";
 
 import Callout, { CalloutResponseViewSchema } from "@models/Callout";
 import CalloutResponse from "@models/CalloutResponse";

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -468,13 +468,10 @@ export async function fetchPaginatedCalloutResponses(
       const responseTags = await createQueryBuilder(CalloutResponseTag, "rt")
         .where("rt.response IN (:...ids)", { ids: responseIds })
         .innerJoinAndSelect("rt.tag", "tag")
-        .loadAllRelationIds({ relations: ["response"] })
         .getMany();
 
       for (const item of results.items) {
-        item.tags = responseTags.filter(
-          (rt) => (rt as any).response === item.id
-        );
+        item.tags = responseTags.filter((rt) => rt.responseId === item.id);
       }
     }
   }

--- a/src/api/data/CalloutResponseData/index.ts
+++ b/src/api/data/CalloutResponseData/index.ts
@@ -15,10 +15,10 @@ import {
 import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns";
 import { NotFoundError } from "routing-controllers";
-import { In, createQueryBuilder } from "typeorm";
+import { In } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 
 import Callout, { CalloutResponseViewSchema } from "@models/Callout";
 import CalloutResponse from "@models/CalloutResponse";
@@ -347,7 +347,7 @@ export async function exportCalloutResponses(
     where: {
       responseId: In(results.items.map((response) => response.id))
     },
-    relations: ["contact"],
+    relations: { contact: true },
     order: { createdAt: "ASC" }
   });
   const commentsByResponseId = groupBy(comments, (c) => c.responseId);

--- a/src/api/data/ContactData/index.ts
+++ b/src/api/data/ContactData/index.ts
@@ -283,10 +283,9 @@ export async function loadContactRoles(contacts: Contact[]): Promise<void> {
       .where("mp.contactId IN (:...ids)", {
         ids: contacts.map((t) => t.id)
       })
-      .loadAllRelationIds()
       .getMany();
     for (const contact of contacts) {
-      contact.roles = roles.filter((p) => (p.contact as any) === contact.id);
+      contact.roles = roles.filter((p) => p.contactId === contact.id);
     }
   }
 }

--- a/src/api/data/ContactData/index.ts
+++ b/src/api/data/ContactData/index.ts
@@ -1,7 +1,8 @@
 import { ContactFilterName, contactFilters } from "@beabee/beabee-common";
 import { stringify } from "csv-stringify/sync";
-import { Brackets, createQueryBuilder } from "typeorm";
+import { Brackets } from "typeorm";
 
+import { createQueryBuilder } from "@core/database";
 import { getMembershipStatus } from "@core/services/PaymentService";
 
 import Contact from "@models/Contact";

--- a/src/api/data/PaginatedData/index.ts
+++ b/src/api/data/PaginatedData/index.ts
@@ -18,6 +18,7 @@ import {
   Brackets,
   createQueryBuilder,
   EntityTarget,
+  ObjectLiteral,
   SelectQueryBuilder,
   UpdateQueryBuilder,
   UpdateResult,
@@ -282,7 +283,10 @@ function buildWhere<Field extends string>(
 }
 
 // DEPRECATED: Remove once SegmentService is gone
-export function buildSelectQuery<Entity, Field extends string>(
+export function buildSelectQuery<
+  Entity extends ObjectLiteral,
+  Field extends string
+>(
   entity: EntityTarget<Entity>,
   ruleGroup: ValidatedRuleGroup<Field> | undefined,
   contact?: Contact,
@@ -295,7 +299,10 @@ export function buildSelectQuery<Entity, Field extends string>(
   return qb;
 }
 
-export async function fetchPaginated<Entity, Field extends string>(
+export async function fetchPaginated<
+  Entity extends ObjectLiteral,
+  Field extends string
+>(
   entity: EntityTarget<Entity>,
   filters: Filters<Field>,
   query: GetPaginatedQuery,
@@ -344,7 +351,10 @@ export async function fetchPaginated<Entity, Field extends string>(
   }
 }
 
-export async function batchUpdate<Entity, Field extends string>(
+export async function batchUpdate<
+  Entity extends ObjectLiteral,
+  Field extends string
+>(
   entity: EntityTarget<Entity>,
   filters: Filters<Field>,
   ruleGroup: RuleGroup,

--- a/src/api/data/PaginatedData/index.ts
+++ b/src/api/data/PaginatedData/index.ts
@@ -16,7 +16,6 @@ import {
 import { BadRequestError } from "routing-controllers";
 import {
   Brackets,
-  createQueryBuilder,
   EntityTarget,
   ObjectLiteral,
   SelectQueryBuilder,
@@ -25,6 +24,8 @@ import {
   WhereExpressionBuilder
 } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+
+import { createQueryBuilder } from "@core/database";
 
 import Contact from "@models/Contact";
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,10 +8,9 @@ import flash from "express-flash";
 import helmet from "helmet";
 
 import appLoader from "@core/app-loader";
-import * as database from "@core/database";
 import { log, requestErrorLogger, requestLogger } from "@core/logging";
 import quickflash from "@core/quickflash";
-import startServer from "@core/server";
+import { initApp, startServer } from "@core/server";
 import sessions from "@core/sessions";
 import { isInvalidType } from "@core/utils";
 
@@ -76,7 +75,7 @@ app.get("/favicon.png", (req, res) => {
 // Log the rest
 app.use(requestLogger);
 
-database.connect().then(async () => {
+initApp().then(async () => {
   // Load some caches and make them immediately available
   await PageSettingsService.reload();
   app.use((req, res, next) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,64 +75,68 @@ app.get("/favicon.png", (req, res) => {
 // Log the rest
 app.use(requestLogger);
 
-initApp().then(async () => {
-  // Load some caches and make them immediately available
-  await PageSettingsService.reload();
-  app.use((req, res, next) => {
-    res.locals.Options = (opt: OptionKey) => OptionsService.getText(opt);
-    res.locals.Options.list = (opt: OptionKey) => OptionsService.getList(opt);
-    res.locals.Options.bool = (opt: OptionKey) => OptionsService.getBool(opt);
-    res.locals.pageSettings = PageSettingsService.getPath(req.path);
-    next();
+initApp()
+  .then(async () => {
+    // Load some caches and make them immediately available
+    await PageSettingsService.reload();
+    app.use((req, res, next) => {
+      res.locals.Options = (opt: OptionKey) => OptionsService.getText(opt);
+      res.locals.Options.list = (opt: OptionKey) => OptionsService.getList(opt);
+      res.locals.Options.bool = (opt: OptionKey) => OptionsService.getBool(opt);
+      res.locals.pageSettings = PageSettingsService.getPath(req.path);
+      next();
+    });
+
+    // Handle sessions
+    sessions(app);
+
+    // CSRF
+    app.use(csrf());
+
+    app.use(function (err, req, res, next) {
+      if (err.code == "EBADCSRFTOKEN") {
+        return res
+          .status(403)
+          .send(
+            "Error: Please make sure cookies are enabled. (CSRF token invalid)"
+          );
+      }
+      next(err);
+    } as ErrorRequestHandler);
+
+    // Include support for notifications
+    app.use(flash());
+    app.use(quickflash);
+
+    // Load apps
+    await appLoader(app);
+
+    // Hook to handle special URLs
+    //app.use( '/s', specialUrlHandler );
+
+    // Ignore QueryFailedError for invalid type, probably just bad URL
+    app.use(function (err, req, res, next) {
+      next(isInvalidType(err) ? undefined : err);
+    } as ErrorRequestHandler);
+
+    // Error 404
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use(function (req, res, next) {
+      res.status(404);
+      res.render("404");
+    });
+
+    app.use(requestErrorLogger);
+
+    // Error 500
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use(function (err, req, res, next) {
+      res.status(500);
+      res.render("500", { error: config.dev ? err.stack : undefined });
+    } as ErrorRequestHandler);
+
+    startServer(app);
+  })
+  .catch((err) => {
+    log.error("Error during initialization", err);
   });
-
-  // Handle sessions
-  sessions(app);
-
-  // CSRF
-  app.use(csrf());
-
-  app.use(function (err, req, res, next) {
-    if (err.code == "EBADCSRFTOKEN") {
-      return res
-        .status(403)
-        .send(
-          "Error: Please make sure cookies are enabled. (CSRF token invalid)"
-        );
-    }
-    next(err);
-  } as ErrorRequestHandler);
-
-  // Include support for notifications
-  app.use(flash());
-  app.use(quickflash);
-
-  // Load apps
-  await appLoader(app);
-
-  // Hook to handle special URLs
-  //app.use( '/s', specialUrlHandler );
-
-  // Ignore QueryFailedError for invalid type, probably just bad URL
-  app.use(function (err, req, res, next) {
-    next(isInvalidType(err) ? undefined : err);
-  } as ErrorRequestHandler);
-
-  // Error 404
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  app.use(function (req, res, next) {
-    res.status(404);
-    res.render("404");
-  });
-
-  app.use(requestErrorLogger);
-
-  // Error 500
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  app.use(function (err, req, res, next) {
-    res.status(500);
-    res.render("500", { error: config.dev ? err.stack : undefined });
-  } as ErrorRequestHandler);
-
-  startServer(app);
-});

--- a/src/apps/discourse/app.ts
+++ b/src/apps/discourse/app.ts
@@ -1,9 +1,9 @@
 import express from "express";
 import DiscourseSSO from "discourse-sso";
-import { getRepository } from "typeorm";
 
 import config from "@config";
 
+import { getRepository } from "@core/database";
 import { isLoggedIn } from "@core/middleware";
 import { hasUser, wrapAsync } from "@core/utils";
 
@@ -23,8 +23,8 @@ app.get(
 
       if (payload && sig && sso.validate(payload as string, sig as string)) {
         const projectContacts = await getRepository(ProjectContact).find({
-          where: { contact: req.user },
-          relations: ["project"]
+          where: { contactId: req.user.id },
+          relations: { project: true }
         });
 
         const groups = projectContacts

--- a/src/apps/gift/app.ts
+++ b/src/apps/gift/app.ts
@@ -91,7 +91,9 @@ app.post(
     if (moment(giftForm.startDate).isBefore(undefined, "day")) {
       error = "flash-gifts-date-in-the-past" as const;
     } else {
-      const contact = await ContactsService.findOne({ email: giftForm.email });
+      const contact = await ContactsService.findOneBy({
+        email: giftForm.email
+      });
       if (contact) {
         error = "flash-gifts-email-duplicate" as const;
       }

--- a/src/apps/gift/app.ts
+++ b/src/apps/gift/app.ts
@@ -110,7 +110,7 @@ app.post(
 
 app.get(
   "/:setupCode",
-  hasNewModel(GiftFlow, "setupCode", { relations: ["giftee"] }),
+  hasNewModel(GiftFlow, "setupCode", { relations: { giftee: true } }),
   wrapAsync(async (req, res, next) => {
     const giftFlow = req.model as GiftFlow;
 

--- a/src/apps/login/app.ts
+++ b/src/apps/login/app.ts
@@ -1,8 +1,8 @@
 import { RoleTypes, RoleType } from "@beabee/beabee-common";
 import express from "express";
 import passport from "passport";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { isValidNextUrl, getNextParam, wrapAsync } from "@core/utils";
 import { loginAndRedirect } from "@core/utils/contact";
 
@@ -39,7 +39,7 @@ if (config.dev) {
         });
         contact = role?.contact;
       } else {
-        contact = await ContactsService.findOne(req.params.id);
+        contact = await ContactsService.findOneBy({ id: req.params.id });
       }
 
       if (contact) {

--- a/src/apps/login/app.ts
+++ b/src/apps/login/app.ts
@@ -35,7 +35,7 @@ if (config.dev) {
           where: {
             type: req.params.id as RoleType
           },
-          relations: ["contact"]
+          relations: { contact: true }
         });
         contact = role?.contact;
       } else {

--- a/src/apps/members/app.ts
+++ b/src/apps/members/app.ts
@@ -1,8 +1,8 @@
 import { RuleGroup } from "@beabee/beabee-common";
 import express, { Request } from "express";
 import queryString from "query-string";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 
@@ -161,7 +161,9 @@ app.get(
 
     const addToProject =
       query.addToProject &&
-      (await getRepository(Project).findOne(query.addToProject as string));
+      (await getRepository(Project).findOneBy({
+        id: query.addToProject as string
+      }));
 
     res.render("index", {
       availableTags,

--- a/src/apps/members/apps/add/app.ts
+++ b/src/apps/members/apps/add/app.ts
@@ -5,8 +5,8 @@ import {
   RoleType
 } from "@beabee/beabee-common";
 import express from "express";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasSchema, isSuperAdmin } from "@core/middleware";
 import { createDateTime, wrapAsync } from "@core/utils";
 

--- a/src/apps/members/apps/member/app.ts
+++ b/src/apps/members/apps/member/app.ts
@@ -1,9 +1,9 @@
 import express from "express";
 import moment from "moment";
-import { getRepository } from "typeorm";
 
 import config from "@config";
 
+import { getRepository } from "@core/database";
 import { isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 import { canSuperAdmin, generateCode } from "@core/utils/auth";
@@ -54,7 +54,7 @@ app.get(
     const availableTags = await getAvailableTags();
 
     const rpFlow = await getRepository(ResetSecurityFlow).findOne({
-      where: { contact: contact },
+      where: { contactId: contact.id },
       order: { date: "DESC" }
     });
 

--- a/src/apps/members/apps/member/app.ts
+++ b/src/apps/members/apps/member/app.ts
@@ -33,7 +33,7 @@ app.use(
     // Bit of a hack to get parent app params
     const contact = await ContactsService.findOne({
       where: { id: req.allParams.uuid },
-      relations: ["profile"]
+      relations: { profile: true }
     });
     if (contact) {
       req.model = contact;

--- a/src/apps/projects/app.ts
+++ b/src/apps/projects/app.ts
@@ -1,9 +1,8 @@
 import express from "express";
 import _ from "lodash";
 import moment from "moment";
-import { createQueryBuilder } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { hasNewModel, hasSchema, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 
@@ -116,17 +115,17 @@ app.post(
 
 app.get(
   "/:id",
-  hasNewModel(Project, "id", { relations: ["owner"] }),
+  hasNewModel(Project, "id", { relations: { owner: true } }),
   wrapAsync(async (req, res) => {
     const project = req.model as Project;
 
     const projectContacts = await getRepository(ProjectContact).find({
       where: { projectId: project.id },
-      relations: ["contact", "contact.profile"]
+      relations: { contact: { profile: true } }
     });
     const engagements = await getRepository(ProjectEngagement).find({
       where: { projectId: project.id },
-      relations: ["byContact", "toContact"]
+      relations: { byContact: true, toContact: true }
     });
 
     const projectContactsWithEngagement = projectContacts.map((pm) => {

--- a/src/apps/projects/app.ts
+++ b/src/apps/projects/app.ts
@@ -1,8 +1,9 @@
 import express from "express";
 import _ from "lodash";
 import moment from "moment";
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasNewModel, hasSchema, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 
@@ -120,11 +121,11 @@ app.get(
     const project = req.model as Project;
 
     const projectContacts = await getRepository(ProjectContact).find({
-      where: { project },
+      where: { projectId: project.id },
       relations: ["contact", "contact.profile"]
     });
     const engagements = await getRepository(ProjectEngagement).find({
-      where: { project },
+      where: { projectId: project.id },
       relations: ["byContact", "toContact"]
     });
 
@@ -189,8 +190,10 @@ app.post(
         res.redirect(req.originalUrl + "#contacts");
         break;
       case "delete":
-        await getRepository(ProjectEngagement).delete({ project });
-        await getRepository(ProjectContact).delete({ project });
+        await getRepository(ProjectEngagement).delete({
+          projectId: project.id
+        });
+        await getRepository(ProjectContact).delete({ projectId: project.id });
         await getRepository(Project).delete(project.id);
         req.flash("success", "project-deleted");
         res.redirect("/projects");

--- a/src/apps/reports/apps/map/app.ts
+++ b/src/apps/reports/apps/map/app.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 import express from "express";
-import { Brackets, createQueryBuilder } from "typeorm";
+import { Brackets } from "typeorm";
 
+import { createQueryBuilder } from "@core/database";
 import { log } from "@core/logging";
 import { isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";

--- a/src/apps/reports/apps/transactions/app.ts
+++ b/src/apps/reports/apps/transactions/app.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import moment from "moment";
-import { Between, getRepository } from "typeorm";
+import { Between } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { isSuperAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 

--- a/src/apps/reports/apps/transactions/app.ts
+++ b/src/apps/reports/apps/transactions/app.ts
@@ -39,7 +39,7 @@ app.get(
         createdAt: Between(start.toDate(), end.toDate())
       },
       order: { chargeDate: "DESC" },
-      relations: ["contact"]
+      relations: { contact: true }
     });
 
     const successfulPayments = payments

--- a/src/apps/settings/apps/content/app.ts
+++ b/src/apps/settings/apps/content/app.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response, NextFunction } from "express";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 

--- a/src/apps/settings/apps/newsletters/app.ts
+++ b/src/apps/settings/apps/newsletters/app.ts
@@ -78,7 +78,9 @@ async function handleResync(
   try {
     await setResyncStatus("In progress: Fetching contact lists");
 
-    const contacts = await ContactsService.find({ relations: ["profile"] });
+    const contacts = await ContactsService.find({
+      relations: { profile: true }
+    });
     const nlContacts = await NewsletterService.getNewsletterContacts();
 
     const newContactsToUpload: Contact[] = [],
@@ -245,7 +247,7 @@ app.get(
     const newContactsToUpload = await ContactsService.findByIds(data.uploadIds);
     const mismatchedContacts = await ContactsService.findByIds(
       data.mismatched.map((m) => m.id),
-      { relations: ["profile"] }
+      { relations: { profile: true } }
     );
 
     res.render("report", {

--- a/src/apps/settings/apps/pages/app.ts
+++ b/src/apps/settings/apps/pages/app.ts
@@ -1,6 +1,6 @@
 import express from "express";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasNewModel, hasSchema, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 

--- a/src/apps/share/app.ts
+++ b/src/apps/share/app.ts
@@ -1,6 +1,6 @@
 import express from "express";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { wrapAsync } from "@core/utils";
 
 import PageSettingsService, {
@@ -20,7 +20,7 @@ async function getCalloutShareSettings(
 ): Promise<JustPageSettings | undefined> {
   const [slug, ...rest] = uri.substring("/callouts/".length).split("/", 1);
 
-  const callout = await getRepository(Callout).findOne(slug);
+  const callout = await getRepository(Callout).findOneBy({ slug });
   if (callout) {
     return {
       shareTitle: callout.shareTitle || callout.title,

--- a/src/apps/tools/apps/emails/app.ts
+++ b/src/apps/tools/apps/emails/app.ts
@@ -2,8 +2,9 @@ import busboy from "connect-busboy";
 import express from "express";
 import _ from "lodash";
 import Papa from "papaparse";
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasNewModel, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 import { formatEmailBody } from "@core/utils/email";
@@ -97,12 +98,12 @@ app.get(
     const email = req.model as Email;
 
     const mailings = await getRepository(EmailMailing).find({
-      where: { email },
+      where: { emailId: email.id },
       order: { createdDate: "ASC" }
     });
     const segmentEmails = await getRepository(SegmentOngoingEmail).find({
-      where: { email },
-      relations: ["segment"]
+      where: { emailId: email.id },
+      relations: { segment: true }
     });
     const systemEmails = Object.entries(providerTemplateMap())
       .filter(([systemId, emailId]) => emailId === email.id)
@@ -149,7 +150,7 @@ app.post(
         break;
       }
       case "delete":
-        await getRepository(EmailMailing).delete({ email });
+        await getRepository(EmailMailing).delete({ emailId: email.id });
         await getRepository(Email).delete(email.id);
         req.flash("success", "transactional-email-deleted");
         res.redirect("/tools/emails");
@@ -186,9 +187,9 @@ app.get(
   hasNewModel(Email, "id"),
   wrapAsync(async (req, res, next) => {
     const email = req.model as Email;
-    const mailing = await getRepository(EmailMailing).findOne(
-      req.params.mailingId
-    );
+    const mailing = await getRepository(EmailMailing).findOneBy({
+      id: req.params.mailingId
+    });
     if (!mailing) return next("route");
 
     const matches = email.body.match(/\*\|[^|]+\|\*/g) || [];
@@ -217,9 +218,9 @@ app.post(
   hasNewModel(Email, "id"),
   wrapAsync(async (req, res, next) => {
     const email = req.model as Email;
-    const mailing = await getRepository(EmailMailing).findOne(
-      req.params.mailingId
-    );
+    const mailing = await getRepository(EmailMailing).findOneBy({
+      id: req.params.mailingId
+    });
     if (!mailing) return next("route");
 
     const { emailField, nameField, mergeFields }: SendSchema = req.body;

--- a/src/apps/tools/apps/emails/app.ts
+++ b/src/apps/tools/apps/emails/app.ts
@@ -2,9 +2,8 @@ import busboy from "connect-busboy";
 import express from "express";
 import _ from "lodash";
 import Papa from "papaparse";
-import { createQueryBuilder } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { hasNewModel, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 import { formatEmailBody } from "@core/utils/email";

--- a/src/apps/tools/apps/emails/app.ts
+++ b/src/apps/tools/apps/emails/app.ts
@@ -67,15 +67,13 @@ app.get(
       .orderBy({ name: "ASC" })
       .getMany();
 
-    const segmentEmails = (await getRepository(SegmentOngoingEmail).find({
-      loadRelationIds: true
-    })) as unknown as WithRelationIds<SegmentOngoingEmail, "email">[];
+    const segmentEmails = await getRepository(SegmentOngoingEmail).find();
     const systemEmails = Object.values(providerTemplateMap());
 
     const emailsWithFlags = emails.map((email) => ({
       ...email,
       isSystem: systemEmails.indexOf(email.id) > -1,
-      isSegment: segmentEmails.findIndex((se) => se.email === email.id) > -1
+      isSegment: segmentEmails.findIndex((se) => se.emailId === email.id) > -1
     }));
 
     res.render("index", { emails: emailsWithFlags });

--- a/src/apps/tools/apps/exports/exports/ActiveMembersExport.ts
+++ b/src/apps/tools/apps/exports/exports/ActiveMembersExport.ts
@@ -1,5 +1,6 @@
-import { Brackets, createQueryBuilder, SelectQueryBuilder } from "typeorm";
+import { Brackets, SelectQueryBuilder } from "typeorm";
 
+import { createQueryBuilder } from "@core/database";
 import { Param } from "@core/utils/params";
 
 import PaymentData from "@models/PaymentData";

--- a/src/apps/tools/apps/exports/exports/BaseExport.ts
+++ b/src/apps/tools/apps/exports/exports/BaseExport.ts
@@ -1,4 +1,4 @@
-import { SelectQueryBuilder } from "typeorm";
+import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
 
 import { Param } from "@core/utils/params";
 
@@ -9,7 +9,7 @@ export type ExportResult =
   | Record<string, unknown>[]
   | { fields: string[]; data: unknown[][] };
 
-export default abstract class BaseExport<T> {
+export default abstract class BaseExport<T extends ObjectLiteral> {
   abstract readonly exportName: string;
   abstract readonly itemName: string;
   abstract readonly itemStatuses: string[];

--- a/src/apps/tools/apps/exports/exports/EditionExport.ts
+++ b/src/apps/tools/apps/exports/exports/EditionExport.ts
@@ -1,7 +1,8 @@
 import { ContributionType } from "@beabee/beabee-common";
 import _ from "lodash";
-import { createQueryBuilder, SelectQueryBuilder } from "typeorm";
+import { SelectQueryBuilder } from "typeorm";
 
+import { createQueryBuilder } from "@core/database";
 import { Param } from "@core/utils/params";
 
 import Contact from "@models/Contact";

--- a/src/apps/tools/apps/exports/exports/GiftsExport.ts
+++ b/src/apps/tools/apps/exports/exports/GiftsExport.ts
@@ -1,5 +1,7 @@
 import { ContributionType } from "@beabee/beabee-common";
-import { createQueryBuilder, SelectQueryBuilder } from "typeorm";
+import { SelectQueryBuilder } from "typeorm";
+
+import { createQueryBuilder } from "@core/database";
 
 import Address from "@models/Address";
 import GiftFlow from "@models/GiftFlow";

--- a/src/apps/tools/apps/exports/exports/ReferralsExport.ts
+++ b/src/apps/tools/apps/exports/exports/ReferralsExport.ts
@@ -1,4 +1,6 @@
-import { createQueryBuilder, SelectQueryBuilder } from "typeorm";
+import { SelectQueryBuilder } from "typeorm";
+
+import { createQueryBuilder } from "@core/database";
 
 import Contact from "@models/Contact";
 import Referral from "@models/Referral";

--- a/src/apps/tools/apps/polls/app.ts
+++ b/src/apps/tools/apps/polls/app.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import moment from "moment";
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasNewModel, hasSchema, isAdmin } from "@core/middleware";
 import { createDateTime, wrapAsync } from "@core/utils";
 
@@ -85,10 +86,11 @@ app.get(
   "/:slug",
   hasNewModel(Callout, "slug"),
   wrapAsync(async (req, res) => {
+    const poll = req.model as Callout;
     const responsesCount = await getRepository(CalloutResponse).count({
-      where: { callout: req.model }
+      where: { calloutSlug: poll.slug }
     });
-    res.render("poll", { poll: req.model, responsesCount });
+    res.render("poll", { poll, responsesCount });
   })
 );
 
@@ -102,11 +104,11 @@ app.get(
       next("route");
     } else {
       const responses = await getRepository(CalloutResponse).find({
-        where: { callout: req.model },
+        where: { calloutSlug: poll.slug },
         order: {
           createdAt: "ASC"
         },
-        relations: ["contact"]
+        relations: { contact: true }
       });
       const responsesWithText = responses.map((response) => ({
         ...response,

--- a/src/apps/tools/apps/referrals/app.ts
+++ b/src/apps/tools/apps/referrals/app.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import _ from "lodash";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { hasNewModel, hasSchema, isAdmin } from "@core/middleware";
 import { wrapAsync } from "@core/utils";
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -91,6 +91,7 @@ export default {
     secure: env.b("BEABEE_COOKIE_SECURE", true)
   },
   trustedOrigins: env.ss("BEABEE_TRUSTEDORIGINS", []),
+  databaseUrl: env.s("BEABEE_DATABASE_URL"),
   discourse: {
     url: env.s("BEABEE_DISCOURSE_URL", ""),
     ssoSecret: env.s("BEABEE_DISCOURSE_SSOSECRET", "")

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -15,15 +15,18 @@ import config from "@config";
 
 const log = mainLogger.child({ app: "database" });
 
-export let dataSource: DataSource;
+export const dataSource: DataSource = new DataSource({
+  type: "postgres",
+  url: config.databaseUrl,
+  logging: config.dev,
+  entities: [__dirname + "/../models/*.js"],
+  migrations: [__dirname + "/../migrations/*.js"]
+});
+
 export function getRepository<Entity extends ObjectLiteral>(
   target: EntityTarget<Entity>
 ): Repository<Entity> {
   return dataSource.getRepository(target);
-}
-
-export function getConnection(): DataSource {
-  return dataSource;
 }
 
 export function createQueryBuilder<Entity extends ObjectLiteral>(
@@ -52,12 +55,6 @@ export function createQueryBuilder<Entity extends ObjectLiteral>(
 
 export async function connect(): Promise<void> {
   try {
-    dataSource = new DataSource({
-      type: "postgres",
-      url: config.databaseUrl,
-      logging: config.dev,
-      entities: [__dirname + "/../models/*.js"]
-    });
     await dataSource.initialize();
     log.info("Connected to database");
   } catch (error) {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1,6 +1,13 @@
 import "reflect-metadata";
 
-import { DataSource, EntityTarget, ObjectLiteral, Repository } from "typeorm";
+import {
+  DataSource,
+  EntityTarget,
+  ObjectLiteral,
+  QueryRunner,
+  Repository,
+  SelectQueryBuilder
+} from "typeorm";
 
 import { log as mainLogger } from "@core/logging";
 
@@ -18,6 +25,30 @@ export function getRepository<Entity extends ObjectLiteral>(
 
 export function getConnection(): DataSource {
   return dataSource;
+}
+
+export function createQueryBuilder<Entity extends ObjectLiteral>(
+  entityClass: EntityTarget<Entity>,
+  alias: string,
+  queryRunner?: QueryRunner
+): SelectQueryBuilder<Entity>;
+export function createQueryBuilder(
+  queryRunner?: QueryRunner
+): SelectQueryBuilder<any>;
+export function createQueryBuilder<Entity extends ObjectLiteral>(
+  arg1?: EntityTarget<Entity> | QueryRunner,
+  alias?: string,
+  queryRunner?: QueryRunner
+): SelectQueryBuilder<Entity> {
+  if (alias) {
+    return dataSource.createQueryBuilder(
+      arg1 as EntityTarget<Entity>,
+      alias,
+      queryRunner
+    );
+  } else {
+    return dataSource.createQueryBuilder(arg1 as QueryRunner);
+  }
 }
 
 export async function connect(): Promise<void> {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -15,6 +15,7 @@ import config from "@config";
 
 const log = mainLogger.child({ app: "database" });
 
+// This is used by the TypeORM CLI to run migrations
 export const dataSource: DataSource = new DataSource({
   type: "postgres",
   url: config.databaseUrl,

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -11,7 +11,6 @@ import {
 
 import { log as mainLogger } from "@core/logging";
 
-import OptionsService from "@core/services/OptionsService";
 import config from "@config";
 
 const log = mainLogger.child({ app: "database" });
@@ -55,11 +54,12 @@ export async function connect(): Promise<void> {
   try {
     dataSource = new DataSource({
       type: "postgres",
-      url: config.databaseUrl
+      url: config.databaseUrl,
+      logging: config.dev,
+      entities: [__dirname + "/../models/*.js"]
     });
     await dataSource.initialize();
     log.info("Connected to database");
-    await OptionsService.reload();
   } catch (error) {
     log.error("Error connecting to database", error);
     process.exit(1);

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -16,6 +16,10 @@ export function getRepository<Entity extends ObjectLiteral>(
   return dataSource.getRepository(target);
 }
 
+export function getConnection(): DataSource {
+  return dataSource;
+}
+
 export async function connect(): Promise<void> {
   try {
     dataSource = new DataSource({

--- a/src/core/lib/gocardless.ts
+++ b/src/core/lib/gocardless.ts
@@ -39,7 +39,7 @@ gocardless.interceptors.request.use((config) => {
   });
 
   if (config.method === "post") {
-    config.headers["Idempotency-Key"] = uuidv4;
+    config.headers["Idempotency-Key"] = uuidv4();
   }
   return config;
 });

--- a/src/core/lib/gocardless.ts
+++ b/src/core/lib/gocardless.ts
@@ -39,7 +39,7 @@ gocardless.interceptors.request.use((config) => {
   });
 
   if (config.method === "post") {
-    (config.headers as any)["Idempotency-Key"] = uuidv4();
+    config.headers["Idempotency-Key"] = uuidv4;
   }
   return config;
 });

--- a/src/core/lib/passport.ts
+++ b/src/core/lib/passport.ts
@@ -1,9 +1,9 @@
 import passport from "passport";
 import passportLocal from "passport-local";
-import { getRepository } from "typeorm";
 
 import config from "@config";
 
+import { getRepository } from "@core/database";
 import { log } from "@core/logging";
 import { cleanEmailAddress, sleep } from "@core/utils";
 import { generatePassword, isValidPassword } from "@core/utils/auth";
@@ -38,7 +38,7 @@ passport.use(
 
       email = cleanEmailAddress(email);
 
-      const contact = await ContactsService.findOne({ email });
+      const contact = await ContactsService.findOneBy({ email });
 
       let code = LOGIN_CODES.LOGIN_FAILED;
 
@@ -137,7 +137,7 @@ passport.serializeUser(function (data, done) {
 passport.deserializeUser(async function (data, done) {
   try {
     if (typeof data === "string") {
-      const contact = await ContactsService.findOne(data);
+      const contact = await ContactsService.findOneBy({ id: data });
       if (contact) {
         // Debounce last seen updates, we don't need to know to the second
         const now = new Date();

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -136,7 +136,7 @@ export function hasNewModel<T extends ObjectLiteral>(
         req.model = await getRepository(entity).findOne({
           where: {
             [prop]: req.params[prop as string]
-          } as any,
+          } as T,
           ...findOpts
         });
       } catch (err) {

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -1,7 +1,8 @@
 import { ErrorObject, ValidateFunction } from "ajv";
 import { NextFunction, Request, RequestHandler, Response } from "express";
-import { EntityTarget, FindOneOptions, getRepository } from "typeorm";
+import { EntityTarget, FindOneOptions, ObjectLiteral } from "typeorm";
 
+import { getRepository } from "@core/database";
 import ajv from "@core/lib/ajv";
 import { wrapAsync, isInvalidType } from "@core/utils";
 import * as auth from "@core/utils/auth";
@@ -124,7 +125,7 @@ export function hasSchema(
   };
 }
 
-export function hasNewModel<T>(
+export function hasNewModel<T extends ObjectLiteral>(
   entity: EntityTarget<T>,
   prop: keyof T,
   findOpts: FindOneOptions<T> = {}
@@ -135,7 +136,7 @@ export function hasNewModel<T>(
         req.model = await getRepository(entity).findOne({
           where: {
             [prop]: req.params[prop as string]
-          },
+          } as any,
           ...findOpts
         });
       } catch (err) {

--- a/src/core/providers/email/BaseProvider.ts
+++ b/src/core/providers/email/BaseProvider.ts
@@ -128,18 +128,18 @@ export default abstract class BaseProvider implements EmailProvider {
   }
 
   async sendTemplate(
-    template: string,
+    templateId: string,
     recipients: EmailRecipient[],
     opts?: EmailOptions
   ): Promise<void> {
-    const email = await getRepository(Email).findOneBy({ id: template });
+    const email = await getRepository(Email).findOneBy({ id: templateId });
     if (email) {
       await this.sendEmail(email, recipients, opts);
     }
   }
 
-  async getTemplateEmail(template: string): Promise<false | Email | null> {
-    return (await getRepository(Email).findOneBy({ id: template })) || null;
+  async getTemplateEmail(templateId: string): Promise<false | Email | null> {
+    return (await getRepository(Email).findOneBy({ id: templateId })) || null;
   }
 
   async getTemplates(): Promise<EmailTemplate[]> {

--- a/src/core/providers/email/BaseProvider.ts
+++ b/src/core/providers/email/BaseProvider.ts
@@ -1,6 +1,4 @@
-import { createQueryBuilder } from "typeorm";
-
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { formatEmailBody } from "@core/utils/email";
 
@@ -43,7 +41,7 @@ function generateResetPasswordLinks(type: "set" | "reset") {
     log.info(`Creating ${emails.length} links for ${mergeField}`);
 
     // Get list of contacts who match the recipients
-    const contacts = await createQueryBuilder(Contact)
+    const contacts = await createQueryBuilder(Contact, "c")
       .select(["id", "email"])
       .where("email IN (:...emails)", { emails })
       .getRawMany<{ id: string; email: string }>();

--- a/src/core/providers/email/BaseProvider.ts
+++ b/src/core/providers/email/BaseProvider.ts
@@ -43,7 +43,7 @@ function generateResetPasswordLinks(type: "set" | "reset") {
     // Get list of contacts who match the recipients
     const contacts = await createQueryBuilder(Contact, "c")
       .select(["id", "email"])
-      .where("email IN (:...emails)", { emails })
+      .where("c.email IN (:...emails)", { emails })
       .getRawMany<{ id: string; email: string }>();
 
     const contactIdsByEmail = Object.fromEntries(

--- a/src/core/providers/email/BaseProvider.ts
+++ b/src/core/providers/email/BaseProvider.ts
@@ -1,5 +1,6 @@
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { formatEmailBody } from "@core/utils/email";
 
@@ -133,14 +134,14 @@ export default abstract class BaseProvider implements EmailProvider {
     recipients: EmailRecipient[],
     opts?: EmailOptions
   ): Promise<void> {
-    const email = await getRepository(Email).findOne(template);
+    const email = await getRepository(Email).findOneBy({ id: template });
     if (email) {
       await this.sendEmail(email, recipients, opts);
     }
   }
 
   async getTemplateEmail(template: string): Promise<false | Email | null> {
-    return (await getRepository(Email).findOne(template)) || null;
+    return (await getRepository(Email).findOneBy({ id: template })) || null;
   }
 
   async getTemplates(): Promise<EmailTemplate[]> {

--- a/src/core/providers/email/MandrillProvider.ts
+++ b/src/core/providers/email/MandrillProvider.ts
@@ -65,29 +65,29 @@ export default class MandrillProvider extends BaseProvider {
   }
 
   async sendTemplate(
-    template: string,
+    templateId: string,
     recipients: EmailRecipient[],
     opts?: EmailOptions
   ): Promise<void> {
-    log.info(`Sending template ${template}`);
+    log.info(`Sending template ${templateId}`);
 
-    if (template.startsWith("mandrill_")) {
+    if (templateId.startsWith("mandrill_")) {
       const resp = await this.instance.post("/messages/send-template", {
         message: this.createMessageData(recipients, opts),
-        template_name: template.substring(9), // Remove mandrill_
+        template_name: templateId.substring(9), // Remove mandrill_
         template_content: [],
         ...(opts?.sendAt && { send_at: opts.sendAt.toISOString() })
       });
-      log.info(`Sent template ${template}`, { data: resp.data });
+      log.info(`Sent template ${templateId}`, { data: resp.data });
     } else {
-      super.sendTemplate(template, recipients, opts);
+      super.sendTemplate(templateId, recipients, opts);
     }
   }
 
-  async getTemplateEmail(template: string): Promise<false | Email | null> {
-    return template.startsWith("mandrill_")
+  async getTemplateEmail(templateId: string): Promise<false | Email | null> {
+    return templateId.startsWith("mandrill_")
       ? false
-      : await super.getTemplateEmail(template);
+      : await super.getTemplateEmail(templateId);
   }
 
   async getTemplates(): Promise<EmailTemplate[]> {

--- a/src/core/providers/email/index.ts
+++ b/src/core/providers/email/index.ts
@@ -40,10 +40,10 @@ export interface EmailProvider {
     opts?: EmailOptions
   ): Promise<void>;
   sendTemplate(
-    template: string,
+    templateId: string,
     recipients: EmailRecipient[],
     opts?: EmailOptions
   ): Promise<void>;
-  getTemplateEmail(template: string): Promise<false | Email | null>;
+  getTemplateEmail(templateId: string): Promise<false | Email | null>;
   getTemplates(): Promise<EmailTemplate[]>;
 }

--- a/src/core/providers/payment/index.ts
+++ b/src/core/providers/payment/index.ts
@@ -1,6 +1,6 @@
 import { PaymentMethod } from "@beabee/beabee-common";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { ContributionInfo, PaymentForm } from "@core/utils";
 
 import { CompletedPaymentFlow } from "@core/providers/payment-flow";

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,6 +1,6 @@
 import express, { Express } from "express";
 
-import { close as closeDb } from "@core/database";
+import * as db from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { wrapAsync } from "@core/utils";
 
@@ -8,34 +8,45 @@ import OptionsService from "@core/services/OptionsService";
 
 const log = mainLogger.child({ app: "server" });
 
-export default function startServer(app: Express) {
+const internalApp = express();
+
+internalApp.post(
+  "/reload",
+  wrapAsync(async (req, res) => {
+    await OptionsService.reload();
+    res.sendStatus(200);
+  })
+);
+
+export async function initApp() {
+  log.info("Initializing app...");
+  await db.connect();
+  await OptionsService.reload();
+}
+
+export function startServer(app: Express) {
   log.info("Starting server...");
 
   app.set("trust proxy", true);
-
-  const internalApp = express();
-
-  internalApp.post(
-    "/reload",
-    wrapAsync(async (req, res) => {
-      await OptionsService.reload();
-      res.sendStatus(200);
-    })
-  );
 
   const server = app.listen(3000);
   const internalServer = internalApp.listen(4000);
 
   process.on("SIGTERM", () => {
     log.debug("Waiting for server to shutdown");
-    closeDb();
-
     internalServer.close();
-    server.close(() => process.exit());
+    server.close();
+    db.close();
 
     setTimeout(() => {
       log.warn("Server was forced to shutdown after timeout");
       process.exit(1);
     }, 20000).unref();
   });
+}
+
+export async function runApp(fn: () => Promise<void>) {
+  await initApp();
+  await fn();
+  await db.close();
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -46,7 +46,11 @@ export function startServer(app: Express) {
 }
 
 export async function runApp(fn: () => Promise<void>) {
-  await initApp();
-  await fn();
+  try {
+    await initApp();
+    await fn();
+  } catch (err) {
+    log.error("Uncaught error", err);
+  }
   await db.close();
 }

--- a/src/core/services/CalloutsService.ts
+++ b/src/core/services/CalloutsService.ts
@@ -25,6 +25,9 @@ class CalloutWithResponse extends Callout {
 }
 
 class CalloutsService {
+  /**
+   * @deprecated
+   */
   async getVisibleCalloutsWithResponses(
     contact: Contact
   ): Promise<CalloutWithResponse[]> {

--- a/src/core/services/CalloutsService.ts
+++ b/src/core/services/CalloutsService.ts
@@ -2,12 +2,13 @@ import {
   CalloutFormSchema,
   CalloutResponseAnswers
 } from "@beabee/beabee-common";
-import { getRepository, IsNull, LessThan } from "typeorm";
+import { IsNull, LessThan } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
 import EmailService from "@core/services/EmailService";
 import NewsletterService from "@core/services/NewsletterService";
 
+import { getRepository } from "@core/database";
 import { isDuplicateIndex } from "@core/utils";
 
 import Contact from "@models/Contact";
@@ -39,7 +40,7 @@ class CalloutsService {
 
     const responses = await getRepository(CalloutResponse).find({
       loadRelationIds: true,
-      where: { contact: contact }
+      where: { contactId: contact.id }
     });
 
     const calloutsWithResponses = callouts.map((callout) => {
@@ -66,7 +67,7 @@ class CalloutsService {
         // Force the correct type as otherwise this errors, not sure why
         formSchema: data.formSchema as QueryDeepPartialEntity<CalloutFormSchema>
       });
-      return await getRepository(Callout).findOneOrFail(slug);
+      return await getRepository(Callout).findOneByOrFail({ slug });
     } catch (err) {
       if (isDuplicateIndex(err, "slug")) {
         if (autoSlug === false) {
@@ -84,14 +85,16 @@ class CalloutsService {
     callout: Callout,
     contact: Contact
   ): Promise<CalloutResponse | undefined> {
-    return await getRepository(CalloutResponse).findOne({
-      where: {
-        callout: { slug: callout.slug },
-        contact: contact
-      },
-      // Get most recent response for callouts with allowMultiple
-      order: { createdAt: "DESC" }
-    });
+    return (
+      (await getRepository(CalloutResponse).findOne({
+        where: {
+          calloutSlug: callout.slug,
+          contactId: contact.id
+        },
+        // Get most recent response for callouts with allowMultiple
+        order: { createdAt: "DESC" }
+      })) || undefined
+    );
   }
 
   async setResponse(
@@ -188,7 +191,7 @@ class CalloutsService {
   ): Promise<CalloutResponse> {
     if (!response.number) {
       const lastResponse = await getRepository(CalloutResponse).findOne({
-        where: { callout: response.callout },
+        where: { calloutSlug: response.callout.slug },
         order: { number: "DESC" }
       });
 

--- a/src/core/services/CalloutsService.ts
+++ b/src/core/services/CalloutsService.ts
@@ -39,16 +39,13 @@ class CalloutsService {
     });
 
     const responses = await getRepository(CalloutResponse).find({
-      loadRelationIds: true,
       where: { contactId: contact.id }
     });
 
     const calloutsWithResponses = callouts.map((callout) => {
       const pwr = new CalloutWithResponse();
       Object.assign(pwr, callout);
-      pwr.response = responses.find(
-        (r) => (r.callout as unknown as string) === callout.slug
-      )!;
+      pwr.response = responses.find((r) => r.calloutSlug === callout.slug)!;
       return pwr;
     });
 

--- a/src/core/services/ContactMfaService.ts
+++ b/src/core/services/ContactMfaService.ts
@@ -1,9 +1,9 @@
-import { getRepository } from "typeorm";
 import { NotFoundError } from "routing-controllers";
 
 import Contact from "@models/Contact";
 import { ContactMfa, ContactMfaSecure } from "@models/ContactMfa";
 
+import { getRepository } from "@core/database";
 import { validateTotpToken } from "@core/utils/auth";
 
 import { LOGIN_CODES } from "@enums/login-codes";
@@ -158,7 +158,7 @@ class ContactMfaService {
    * @returns The **insecure** contact MFA with the `secret` key
    */
   private async getByIdInsecure(id: string): Promise<ContactMfa | null> {
-    const mfa = await getRepository(ContactMfa).findOne(id);
+    const mfa = await getRepository(ContactMfa).findOneBy({ id });
     return mfa || null;
   }
 

--- a/src/core/services/ContactsService.ts
+++ b/src/core/services/ContactsService.ts
@@ -4,15 +4,9 @@ import {
   ContributionPeriod,
   NewsletterStatus
 } from "@beabee/beabee-common";
-import {
-  createQueryBuilder,
-  FindManyOptions,
-  FindOneOptions,
-  FindOptionsWhere,
-  In
-} from "typeorm";
+import { FindManyOptions, FindOneOptions, FindOptionsWhere, In } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { cleanEmailAddress, isDuplicateIndex, PaymentForm } from "@core/utils";
 import { generatePassword, isValidPassword } from "@core/utils/auth";

--- a/src/core/services/ContactsService.ts
+++ b/src/core/services/ContactsService.ts
@@ -6,12 +6,13 @@ import {
 } from "@beabee/beabee-common";
 import {
   createQueryBuilder,
-  FindConditions,
   FindManyOptions,
   FindOneOptions,
-  getRepository
+  FindOptionsWhere,
+  In
 } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { cleanEmailAddress, isDuplicateIndex, PaymentForm } from "@core/utils";
 import { generatePassword, isValidPassword } from "@core/utils/auth";
@@ -61,32 +62,31 @@ class ContactsService {
     ids: string[],
     options?: FindOneOptions<Contact>
   ): Promise<Contact[]> {
-    return await getRepository(Contact).findByIds(ids, options);
+    return await getRepository(Contact).findBy({ id: In(ids), ...options });
   }
 
   async findOne(
-    id?: string,
-    options?: FindOneOptions<Contact>
-  ): Promise<Contact | undefined>;
-  async findOne(
-    options?: FindOneOptions<Contact>
-  ): Promise<Contact | undefined>;
-  async findOne(
-    conditions: FindConditions<Contact>,
-    options?: FindOneOptions<Contact>
-  ): Promise<Contact | undefined>;
-  async findOne(
-    arg1?: string | FindConditions<Contact> | FindOneOptions<Contact>,
-    arg2?: FindOneOptions<Contact>
+    options: FindOneOptions<Contact>
   ): Promise<Contact | undefined> {
-    return await getRepository(Contact).findOne(arg1 as any, arg2);
+    // TODO: check undefined
+    return (await getRepository(Contact).findOne(options)) || undefined;
+  }
+
+  async findOneBy(
+    where: FindOptionsWhere<Contact>
+  ): Promise<Contact | undefined> {
+    // TODO: check undefined
+    return (await getRepository(Contact).findOneBy(where)) || undefined;
   }
 
   async findByLoginOverride(code: string): Promise<Contact | undefined> {
-    return await createQueryBuilder(Contact, "m")
-      .where("m.loginOverride ->> 'code' = :code", { code: code })
-      .andWhere("m.loginOverride ->> 'expires' > :now", { now: new Date() })
-      .getOne();
+    // TODO: check undefined
+    return (
+      (await createQueryBuilder(Contact, "m")
+        .where("m.loginOverride ->> 'code' = :code", { code: code })
+        .andWhere("m.loginOverride ->> 'expires' > :now", { now: new Date() })
+        .getOne()) || undefined
+    );
   }
 
   async createContact(
@@ -262,7 +262,7 @@ class ContactsService {
     log.info(`Revoke role ${roleType} for ${contact.id}`);
     contact.roles = contact.roles.filter((p) => p.type !== roleType);
     const ret = await getRepository(ContactRole).delete({
-      contact: contact,
+      contactId: contact.id,
       type: roleType
     });
 
@@ -287,8 +287,8 @@ class ContactsService {
     let isFirstSync = false;
 
     if (shouldSync) {
-      contact.profile = await getRepository(ContactProfile).findOneOrFail({
-        contact
+      contact.profile = await getRepository(ContactProfile).findOneByOrFail({
+        contactId: contact.id
       });
       // If this is the first time the contact is being synced to the newsletter
       // then we need to set the active member tag
@@ -436,7 +436,7 @@ class ContactsService {
     email: string,
     resetUrl: string
   ): Promise<void> {
-    const contact = await this.findOne({ email });
+    const contact = await this.findOneBy({ email });
 
     if (!contact) {
       return;
@@ -532,7 +532,7 @@ class ContactsService {
     type: RESET_SECURITY_FLOW_TYPE,
     resetUrl: string
   ): Promise<void> {
-    const contact = await this.findOne({ email });
+    const contact = await this.findOneBy({ email });
 
     // We don't want to leak if the email exists or not
     if (!contact) {

--- a/src/core/services/GiftService.ts
+++ b/src/core/services/GiftService.ts
@@ -69,7 +69,7 @@ export default class GiftService {
         {
           type: "application/pdf",
           name: "Gift card.pdf",
-          content: (giftCard as any).toString("base64")
+          content: giftCard.toString("base64")
         }
       ];
 

--- a/src/core/services/NewsletterService.ts
+++ b/src/core/services/NewsletterService.ts
@@ -1,4 +1,6 @@
 import { NewsletterStatus } from "@beabee/beabee-common";
+
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 
 import {
@@ -10,10 +12,9 @@ import MailchimpProvider from "@core/providers/newsletter/MailchimpProvider";
 import NoneProvider from "@core/providers/newsletter/NoneProvider";
 
 import Contact from "@models/Contact";
+import ContactProfile from "@models/ContactProfile";
 
 import config from "@config";
-import { getRepository } from "typeorm";
-import ContactProfile from "@models/ContactProfile";
 
 const log = mainLogger.child({ app: "newsletter-service" });
 
@@ -34,8 +35,8 @@ async function contactToNlUpdate(
 ): Promise<UpdateNewsletterContact | undefined> {
   // TODO: Fix that it relies on contact.profile being loaded
   if (!contact.profile) {
-    contact.profile = await getRepository(ContactProfile).findOneOrFail({
-      contact: contact
+    contact.profile = await getRepository(ContactProfile).findOneByOrFail({
+      contactId: contact.id
     });
   }
 

--- a/src/core/services/OptionsService.ts
+++ b/src/core/services/OptionsService.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import _defaultOptions from "@core/defaults.json";
 import { log as mainLogger } from "@core/logging";
 

--- a/src/core/services/PageSettingsService.ts
+++ b/src/core/services/PageSettingsService.ts
@@ -1,7 +1,8 @@
-import { getRepository } from "typeorm";
+import { getRepository } from "@core/database";
+
+import OptionsService from "@core/services/OptionsService";
 
 import PageSettings from "@models/PageSettings";
-import OptionsService from "./OptionsService";
 
 interface PageSettingsCache extends PageSettings {
   patternRegex: RegExp;

--- a/src/core/services/PaymentFlowService.ts
+++ b/src/core/services/PaymentFlowService.ts
@@ -1,6 +1,6 @@
 import { ContributionPeriod, PaymentMethod } from "@beabee/beabee-common";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 
 import EmailService from "@core/services/EmailService";
@@ -87,8 +87,8 @@ class PaymentFlowService implements PaymentFlowProvider {
 
   async getJoinFlowByPaymentId(
     paymentFlowId: string
-  ): Promise<JoinFlow | undefined> {
-    return await getRepository(JoinFlow).findOne({ paymentFlowId });
+  ): Promise<JoinFlow | null> {
+    return await getRepository(JoinFlow).findOneBy({ paymentFlowId });
   }
 
   async completeJoinFlow(joinFlow: JoinFlow): Promise<CompletedPaymentFlow> {
@@ -101,7 +101,7 @@ class PaymentFlowService implements PaymentFlowProvider {
   async sendConfirmEmail(joinFlow: JoinFlow): Promise<void> {
     log.info("Send confirm email for " + joinFlow.id);
 
-    const contact = await ContactsService.findOne({
+    const contact = await ContactsService.findOneBy({
       email: joinFlow.joinForm.email
     });
 
@@ -146,7 +146,7 @@ class PaymentFlowService implements PaymentFlowProvider {
     // get a confirm email if they are already an active member
     let contact = await ContactsService.findOne({
       where: { email: joinFlow.joinForm.email },
-      relations: ["profile"]
+      relations: { profile: true }
     });
     if (contact?.membership?.isActive) {
       throw new DuplicateEmailError();

--- a/src/core/services/PaymentService.ts
+++ b/src/core/services/PaymentService.ts
@@ -1,8 +1,9 @@
 import { PaymentMethod } from "@beabee/beabee-common";
-import { createQueryBuilder, getRepository } from "typeorm";
+import { createQueryBuilder } from "typeorm";
 
-import { ContributionInfo, PaymentForm } from "@core/utils";
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
+import { ContributionInfo, PaymentForm } from "@core/utils";
 import { calcRenewalDate } from "@core/utils/payment";
 
 import Contact from "@models/Contact";
@@ -42,7 +43,9 @@ type ProviderFn<T> = (p: PaymentProvider<any>, data: PaymentData) => Promise<T>;
 
 class PaymentService {
   async getData(contact: Contact): Promise<PaymentData> {
-    const data = await getRepository(PaymentData).findOneOrFail(contact.id);
+    const data = await getRepository(PaymentData).findOneByOrFail({
+      contactId: contact.id
+    });
     log.info("Loaded data for " + contact.id, { data });
     // Load full contact into data
     return { ...data, contact: contact };
@@ -58,7 +61,8 @@ class PaymentService {
       .where(`data->>:key = :value`, { key, value })
       .getOne();
 
-    return data;
+    // TODO: check undefined
+    return data || undefined;
   }
 
   async updateDataBy(contact: Contact, key: string, value: unknown) {
@@ -132,7 +136,7 @@ class PaymentService {
   }
 
   async getPayments(contact: Contact): Promise<Payment[]> {
-    return await getRepository(Payment).find({ contact: contact });
+    return await getRepository(Payment).findBy({ contactId: contact.id });
   }
 
   async createContact(contact: Contact): Promise<void> {
@@ -156,7 +160,10 @@ class PaymentService {
     const ret = await this.provider(contact, (p) =>
       p.updateContribution(paymentForm)
     );
-    await getRepository(PaymentData).update({ contact }, { cancelledAt: null });
+    await getRepository(PaymentData).update(
+      { contactId: contact.id },
+      { cancelledAt: null }
+    );
     return ret;
   }
 
@@ -195,15 +202,15 @@ class PaymentService {
     log.info("Cancel contribution for " + contact.id);
     await this.provider(contact, (p) => p.cancelContribution(keepMandate));
     await getRepository(PaymentData).update(
-      { contact },
+      { contactId: contact.id },
       { cancelledAt: new Date() }
     );
   }
 
   async permanentlyDeleteContact(contact: Contact): Promise<void> {
     await this.provider(contact, (p) => p.permanentlyDeleteContact());
-    await getRepository(PaymentData).delete({ contact: contact });
-    await getRepository(Payment).delete({ contact: contact });
+    await getRepository(PaymentData).delete({ contactId: contact.id });
+    await getRepository(Payment).delete({ contactId: contact.id });
   }
 }
 

--- a/src/core/services/PaymentService.ts
+++ b/src/core/services/PaymentService.ts
@@ -1,7 +1,6 @@
 import { PaymentMethod } from "@beabee/beabee-common";
-import { createQueryBuilder } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import { ContributionInfo, PaymentForm } from "@core/utils";
 import { calcRenewalDate } from "@core/utils/payment";

--- a/src/core/services/ReferralsService.ts
+++ b/src/core/services/ReferralsService.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 
 import EmailService from "@core/services/EmailService";
@@ -23,7 +23,7 @@ export default class ReferralsService {
   ): Promise<boolean> {
     if (!giftForm.referralGift) return true; // No gift option
 
-    const gift = await getRepository(ReferralGift).findOne({
+    const gift = await getRepository(ReferralGift).findOneBy({
       name: giftForm.referralGift
     });
     if (gift && gift.enabled && gift.minAmount <= amount) {
@@ -45,7 +45,7 @@ export default class ReferralsService {
     log.info("Update gift stock", giftForm);
 
     if (giftForm.referralGift) {
-      const gift = await getRepository(ReferralGift).findOne({
+      const gift = await getRepository(ReferralGift).findOneBy({
         name: giftForm.referralGift
       });
       if (gift && giftForm.referralGiftOptions) {
@@ -104,7 +104,7 @@ export default class ReferralsService {
   static async getContactReferrals(referrer: Contact): Promise<Referral[]> {
     return await getRepository(Referral).find({
       relations: ["referrerGift", "referee"],
-      where: { referrer }
+      where: { referrerId: referrer.id }
     });
   }
 
@@ -134,7 +134,7 @@ export default class ReferralsService {
 
   static async permanentlyDeleteContact(contact: Contact): Promise<void> {
     await getRepository(Referral).update(
-      { referrer: contact },
+      { referrerId: contact.id },
       { referrer: null }
     );
   }

--- a/src/core/services/ReferralsService.ts
+++ b/src/core/services/ReferralsService.ts
@@ -103,7 +103,7 @@ export default class ReferralsService {
 
   static async getContactReferrals(referrer: Contact): Promise<Referral[]> {
     return await getRepository(Referral).find({
-      relations: ["referrerGift", "referee"],
+      relations: { referrerGift: true, referee: true },
       where: { referrerId: referrer.id }
     });
   }

--- a/src/core/services/ResetSecurityFlowService.ts
+++ b/src/core/services/ResetSecurityFlowService.ts
@@ -1,7 +1,7 @@
 import { subHours } from "date-fns";
-import { InsertResult, MoreThan, createQueryBuilder } from "typeorm";
+import { InsertResult, MoreThan } from "typeorm";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 
 import ResetSecurityFlow from "@models/ResetSecurityFlow";
 import Contact from "@models/Contact";
@@ -72,7 +72,7 @@ class ResetSecurityFlowService {
   async get(id: string) {
     return await getRepository(ResetSecurityFlow).findOne({
       where: { id, date: MoreThan(subHours(new Date(), 24)) },
-      relations: ["contact"]
+      relations: { contact: true }
     });
   }
 }

--- a/src/core/services/ResetSecurityFlowService.ts
+++ b/src/core/services/ResetSecurityFlowService.ts
@@ -1,10 +1,7 @@
 import { subHours } from "date-fns";
-import {
-  InsertResult,
-  MoreThan,
-  createQueryBuilder,
-  getRepository
-} from "typeorm";
+import { InsertResult, MoreThan, createQueryBuilder } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import ResetSecurityFlow from "@models/ResetSecurityFlow";
 import Contact from "@models/Contact";
@@ -62,7 +59,9 @@ class ResetSecurityFlowService {
    * @param contact The contact
    */
   async deleteAll(contact: Contact) {
-    return await getRepository(ResetSecurityFlow).delete({ contact });
+    return await getRepository(ResetSecurityFlow).delete({
+      contactId: contact.id
+    });
   }
 
   /**

--- a/src/core/services/SegmentService.ts
+++ b/src/core/services/SegmentService.ts
@@ -1,5 +1,6 @@
 import { contactFilters, validateRuleGroup } from "@beabee/beabee-common";
-import { getRepository } from "typeorm";
+
+import { getRepository } from "@core/database";
 
 import Contact from "@models/Contact";
 import Segment from "@models/Segment";

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -2,9 +2,9 @@ import { RoleType } from "@beabee/beabee-common";
 import _pgSession from "connect-pg-simple";
 import express, { Response } from "express";
 import session from "express-session";
-import { getConnection } from "typeorm";
 import { PostgresDriver } from "typeorm/driver/postgres/PostgresDriver";
 
+import { getConnection } from "@core/database";
 import passport from "@core/lib/passport";
 
 import config from "@config";

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -4,7 +4,7 @@ import express, { Response } from "express";
 import session from "express-session";
 import { PostgresDriver } from "typeorm/driver/postgres/PostgresDriver";
 
-import { getConnection } from "@core/database";
+import { dataSource } from "@core/database";
 import passport from "@core/lib/passport";
 
 import config from "@config";
@@ -33,7 +33,7 @@ export default (app: express.Express): void => {
       },
       saveUninitialized: false,
       store: new pgSession({
-        pool: (getConnection().driver as PostgresDriver).master
+        pool: (dataSource.driver as PostgresDriver).master
       }),
       resave: false,
       rolling: true

--- a/src/migrations/1701968585255-UpdateIndexes.ts
+++ b/src/migrations/1701968585255-UpdateIndexes.ts
@@ -1,126 +1,353 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class UpdateIndexes1701968585255 implements MigrationInterface {
-    name = 'UpdateIndexes1701968585255'
+  name = "UpdateIndexes1701968585255";
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`);
-        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`);
-        await queryRunner.query(`ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3"`);
-        await queryRunner.query(`ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`);
-        await queryRunner.query(`ALTER TABLE "export_item" ALTER COLUMN "exportId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" ALTER COLUMN "emailId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`);
-        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55"`);
-        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`);
-        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "ownerId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "projectId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "contactId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "projectId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`);
-        await queryRunner.query(`ALTER TABLE "referral" ALTER COLUMN "refereeId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" SET NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" SET NOT NULL`);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("exportId", "itemId") `);
-        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`);
-        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" DROP CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" ALTER COLUMN "exportId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" ALTER COLUMN "emailId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" DROP CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" ALTER COLUMN "ownerId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ALTER COLUMN "projectId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ALTER COLUMN "contactId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "projectId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" ALTER COLUMN "refereeId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" SET NOT NULL`
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("exportId", "itemId") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`);
-        await queryRunner.query(`ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`);
-        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`);
-        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`);
-        await queryRunner.query(`ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`);
-        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`);
-        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`);
-        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "referral" ALTER COLUMN "refereeId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "projectId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "contactId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "projectId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "ownerId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55" UNIQUE ("contactId")`);
-        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" ALTER COLUMN "emailId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "export_item" ALTER COLUMN "exportId" DROP NOT NULL`);
-        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("itemId", "exportId") `);
-        await queryRunner.query(`ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3" UNIQUE ("contactId")`);
-        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" DROP NOT NULL`);
-        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`);
-        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" ALTER COLUMN "refereeId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ALTER COLUMN "projectId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ALTER COLUMN "contactId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ALTER COLUMN "projectId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" ALTER COLUMN "ownerId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" ADD CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55" UNIQUE ("contactId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" ALTER COLUMN "emailId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" ALTER COLUMN "exportId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("itemId", "exportId") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" ADD CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3" UNIQUE ("contactId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" DROP NOT NULL`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
 }

--- a/src/migrations/1701968585255-UpdateIndexes.ts
+++ b/src/migrations/1701968585255-UpdateIndexes.ts
@@ -1,0 +1,126 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateIndexes1701968585255 implements MigrationInterface {
+    name = 'UpdateIndexes1701968585255'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`);
+        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`);
+        await queryRunner.query(`ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3"`);
+        await queryRunner.query(`ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`);
+        await queryRunner.query(`ALTER TABLE "export_item" ALTER COLUMN "exportId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" ALTER COLUMN "emailId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`);
+        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55"`);
+        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`);
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "ownerId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "projectId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "contactId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "projectId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`);
+        await queryRunner.query(`ALTER TABLE "referral" ALTER COLUMN "refereeId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" SET NOT NULL`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("exportId", "itemId") `);
+        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`);
+        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba"`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" DROP CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09"`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" DROP CONSTRAINT "FK_95804d4501f49efddbdb435a929"`);
+        await queryRunner.query(`ALTER TABLE "referral" DROP CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_cb736b479149455f456cdc6bd5f"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3"`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" DROP CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "FK_9010008b8cc4459ff3399935c7a"`);
+        await queryRunner.query(`ALTER TABLE "project" DROP CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed"`);
+        await queryRunner.query(`ALTER TABLE "payment_data" DROP CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55"`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" DROP CONSTRAINT "FK_d84a796de936f37086075c8cc0a"`);
+        await queryRunner.query(`ALTER TABLE "export_item" DROP CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f"`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" DROP CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3"`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68"`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" DROP CONSTRAINT "FK_49079a033f285ccfa789aba2efa"`);
+        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32"`);
+        await queryRunner.query(`ALTER TABLE "project_contact" DROP CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56"`);
+        await queryRunner.query(`ALTER TABLE "callout_response" DROP CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b5152e07fe3321acd931df5783"`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "emailId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ALTER COLUMN "segmentId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_fef3c998a2489b528d8eba1e3ba" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "segment_ongoing_email" ADD CONSTRAINT "FK_d9725a78330e4f18d3cd55cdf09" FOREIGN KEY ("segmentId") REFERENCES "segment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" ALTER COLUMN "contactId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "reset_security_flow" ADD CONSTRAINT "FK_95804d4501f49efddbdb435a929" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "referral" ALTER COLUMN "refereeId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "referral" ADD CONSTRAINT "FK_91b466a38c1ba22e058a405bbc2" FOREIGN KEY ("refereeId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "toContactId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "byContactId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ALTER COLUMN "projectId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_cb736b479149455f456cdc6bd5f" FOREIGN KEY ("toContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_f5bedfe10dbd4e39acff4d714d3" FOREIGN KEY ("byContactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_engagement" ADD CONSTRAINT "FK_39981c5a5237f7b2003a6d979b4" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "contactId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ALTER COLUMN "projectId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "UQ_8f3a11c5ed404fabef99cbbab56" UNIQUE ("projectId", "contactId")`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_324cf3b9fb1cb8ad95c28949b0a" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project_contact" ADD CONSTRAINT "FK_9010008b8cc4459ff3399935c7a" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "project" ALTER COLUMN "ownerId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "project" ADD CONSTRAINT "FK_9884b2ee80eb70b7db4f12e8aed" FOREIGN KEY ("ownerId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "UQ_a2c17e82f66eefb33d47feb4b55" UNIQUE ("contactId")`);
+        await queryRunner.query(`ALTER TABLE "payment_data" ADD CONSTRAINT "FK_a2c17e82f66eefb33d47feb4b55" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" ALTER COLUMN "emailId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "email_mailing" ADD CONSTRAINT "FK_d84a796de936f37086075c8cc0a" FOREIGN KEY ("emailId") REFERENCES "email"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "export_item" ALTER COLUMN "exportId" DROP NOT NULL`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b5152e07fe3321acd931df5783" ON "export_item" ("itemId", "exportId") `);
+        await queryRunner.query(`ALTER TABLE "export_item" ADD CONSTRAINT "FK_5b7cd3804057bcd15f4ae4a751f" FOREIGN KEY ("exportId") REFERENCES "export"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "UQ_f926258b8d2aa36053b4488d3a3" UNIQUE ("contactId")`);
+        await queryRunner.query(`ALTER TABLE "contact_profile" ADD CONSTRAINT "FK_f926258b8d2aa36053b4488d3a3" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "responseId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ALTER COLUMN "contactId" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_81b0d2a988cfd8d34ad7fc3bb68" FOREIGN KEY ("responseId") REFERENCES "callout_response"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "callout_response_comment" ADD CONSTRAINT "FK_49079a033f285ccfa789aba2efa" FOREIGN KEY ("contactId") REFERENCES "contact"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "callout_response" ALTER COLUMN "calloutSlug" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "UQ_df2d4c28d0a020a3bffefb15bfe" UNIQUE ("calloutSlug", "number")`);
+        await queryRunner.query(`ALTER TABLE "callout_response" ADD CONSTRAINT "FK_5d04ff6c1cd96b3e445cf2a3d32" FOREIGN KEY ("calloutSlug") REFERENCES "callout"("slug") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/models/CalloutResponse.ts
+++ b/src/models/CalloutResponse.ts
@@ -58,6 +58,8 @@ export default class CalloutResponse {
   @OneToMany("CalloutResponseTag", "response")
   tags!: CalloutResponseTag[];
 
+  @Column({ type: String, nullable: true })
+  assigneeId!: string | null;
   @ManyToOne("Contact", { nullable: true })
   assignee!: Contact | null;
 

--- a/src/models/CalloutResponse.ts
+++ b/src/models/CalloutResponse.ts
@@ -21,12 +21,16 @@ export default class CalloutResponse {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  calloutSlug!: string;
   @ManyToOne("Callout", "responses")
   callout!: Callout;
 
   @Column()
   number!: number;
 
+  @Column({ type: String, nullable: true })
+  contactId!: string | null;
   @ManyToOne("Contact", { nullable: true })
   contact!: Contact | null;
 

--- a/src/models/CalloutResponseComment.ts
+++ b/src/models/CalloutResponseComment.ts
@@ -15,19 +15,17 @@ export default class CalloutResponseComment {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  contactId!: string;
   @ManyToOne((type) => Contact)
   @JoinColumn()
   contact!: Contact;
 
   @Column()
-  contactId!: string;
-
+  responseId!: string;
   @ManyToOne((type) => CalloutResponse)
   @JoinColumn()
   response!: CalloutResponse;
-
-  @Column()
-  responseId!: string;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/src/models/CalloutResponseTag.ts
+++ b/src/models/CalloutResponseTag.ts
@@ -1,13 +1,17 @@
-import { CreateDateColumn, Entity, ManyToOne } from "typeorm";
+import { CreateDateColumn, Entity, ManyToOne, PrimaryColumn } from "typeorm";
 import CalloutResponse from "./CalloutResponse";
 import CalloutTag from "./CalloutTag";
 
 @Entity({})
 export default class CalloutResponseTag {
-  @ManyToOne("CalloutResponse", "tags", { primary: true })
+  @PrimaryColumn()
+  responseId!: string;
+  @ManyToOne("CalloutResponse", "tags")
   response!: CalloutResponse;
 
-  @ManyToOne("CalloutTag", { primary: true })
+  @PrimaryColumn()
+  tagId!: string;
+  @ManyToOne("CalloutTag")
   tag!: CalloutTag;
 
   @CreateDateColumn()

--- a/src/models/ContactProfile.ts
+++ b/src/models/ContactProfile.ts
@@ -1,12 +1,15 @@
 import { NewsletterStatus } from "@beabee/beabee-common";
-import { Column, Entity, JoinColumn, OneToOne } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
 
 import type Address from "./Address";
 import type Contact from "./Contact";
 
 @Entity()
 export default class ContactProfile {
-  @OneToOne("Contact", "profile", { primary: true })
+  @PrimaryColumn()
+  contactId!: string;
+
+  @OneToOne("Contact", "profile")
   @JoinColumn()
   contact!: Contact;
 

--- a/src/models/ContactRole.ts
+++ b/src/models/ContactRole.ts
@@ -10,7 +10,9 @@ import type Contact from "./Contact";
 
 @Entity()
 export default class ContactRole {
-  @ManyToOne("Contact", "roles", { primary: true })
+  @PrimaryColumn()
+  contactId!: string;
+  @ManyToOne("Contact", "roles")
   contact!: Contact;
 
   @PrimaryColumn()

--- a/src/models/EmailMailing.ts
+++ b/src/models/EmailMailing.ts
@@ -14,6 +14,8 @@ export default class EmailMailing {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  emailId!: string;
   @ManyToOne("Email", "mailings")
   email!: Email;
 

--- a/src/models/ExportItem.ts
+++ b/src/models/ExportItem.ts
@@ -13,6 +13,8 @@ export default class ExportItem {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  exportId!: string;
   @ManyToOne(() => Export)
   export!: Export;
 

--- a/src/models/GiftFlow.ts
+++ b/src/models/GiftFlow.ts
@@ -64,6 +64,8 @@ export default class GiftFlow {
   @Column({ default: false })
   processed!: boolean;
 
+  @Column({ type: String, nullable: true })
+  gifteeId!: string | null;
   @ManyToOne("Contact")
   giftee?: Contact;
 }

--- a/src/models/Payment.ts
+++ b/src/models/Payment.ts
@@ -17,6 +17,8 @@ export default class Payment {
   @Column({ type: String, nullable: true })
   subscriptionId!: string | null;
 
+  @Column({ type: String, nullable: true })
+  contactId!: string | null;
   @ManyToOne("Contact", { nullable: true })
   contact!: Contact | null;
 

--- a/src/models/PaymentData.ts
+++ b/src/models/PaymentData.ts
@@ -1,5 +1,5 @@
 import { PaymentMethod } from "@beabee/beabee-common";
-import { Column, Entity, JoinColumn, OneToOne } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
 
 import type Contact from "./Contact";
 
@@ -38,7 +38,9 @@ export type PaymentProviderData =
 
 @Entity()
 export default class PaymentData {
-  @OneToOne("Contact", "paymentData", { primary: true })
+  @PrimaryColumn()
+  contactId!: string;
+  @OneToOne("Contact", "paymentData")
   @JoinColumn()
   contact!: Contact;
 

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -18,6 +18,8 @@ export default class Project {
   @CreateDateColumn()
   date!: Date;
 
+  @Column()
+  ownerId!: string;
   @ManyToOne("Contact")
   owner!: Contact;
 

--- a/src/models/ProjectContact.ts
+++ b/src/models/ProjectContact.ts
@@ -14,9 +14,13 @@ export default class ProjectContact {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  projectId!: string;
   @ManyToOne("Project", "contacts")
   project!: Project;
 
+  @Column()
+  contactId!: string;
   @ManyToOne("Contact")
   contact!: Contact;
 

--- a/src/models/ProjectEngagement.ts
+++ b/src/models/ProjectEngagement.ts
@@ -14,6 +14,8 @@ export default class ProjectEngagement {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  projectId!: string;
   @ManyToOne("Project")
   project!: Project;
 

--- a/src/models/ProjectEngagement.ts
+++ b/src/models/ProjectEngagement.ts
@@ -19,9 +19,13 @@ export default class ProjectEngagement {
   @ManyToOne("Project")
   project!: Project;
 
+  @Column()
+  byContactId!: string;
   @ManyToOne("Contact")
   byContact!: Contact;
 
+  @Column()
+  toContactId!: string;
   @ManyToOne("Contact")
   toContact!: Contact;
 

--- a/src/models/Referral.ts
+++ b/src/models/Referral.ts
@@ -17,9 +17,13 @@ export default class Referral {
   @CreateDateColumn()
   date!: Date;
 
+  @Column({ type: String, nullable: true })
+  referrerId!: string;
   @ManyToOne("Contact", { nullable: true })
   referrer!: Contact | null;
 
+  @Column()
+  refereeId!: string;
   @ManyToOne("Contact")
   referee!: Contact;
 

--- a/src/models/ResetSecurityFlow.ts
+++ b/src/models/ResetSecurityFlow.ts
@@ -13,6 +13,8 @@ export default class ResetSecurityFlow {
   @PrimaryGeneratedColumn("uuid")
   id!: string;
 
+  @Column()
+  contactId!: string;
   @ManyToOne("Contact")
   contact!: Contact;
 

--- a/src/models/SegmentContact.ts
+++ b/src/models/SegmentContact.ts
@@ -1,14 +1,18 @@
-import { CreateDateColumn, Entity, ManyToOne } from "typeorm";
+import { CreateDateColumn, Entity, ManyToOne, PrimaryColumn } from "typeorm";
 
 import type Contact from "./Contact";
 import type Segment from "./Segment";
 
 @Entity()
 export default class SegmentContact {
-  @ManyToOne("Segment", "contacts", { primary: true })
+  @PrimaryColumn()
+  segmentId!: string;
+  @ManyToOne("Segment", "contacts")
   segment!: Segment;
 
-  @ManyToOne("Contact", { primary: true })
+  @PrimaryColumn()
+  contactId!: string;
+  @ManyToOne("Contact")
   contact!: Contact;
 
   @CreateDateColumn()

--- a/src/models/SegmentOngoingEmail.ts
+++ b/src/models/SegmentOngoingEmail.ts
@@ -17,12 +17,16 @@ export default class SegmentOngoingEmail {
   @CreateDateColumn()
   date!: Date;
 
+  @Column()
+  segmentId!: string;
   @ManyToOne("Segment")
   segment!: Segment;
 
   @Column()
   trigger!: string;
 
+  @Column()
+  emailId!: string;
   @ManyToOne("Email")
   email!: Email;
 

--- a/src/tools/configure.ts
+++ b/src/tools/configure.ts
@@ -7,12 +7,13 @@ import * as db from "@core/database";
 import OptionsService from "@core/services/OptionsService";
 
 import Content from "@models/Content";
+import { initApp } from "@core/server";
 
 function notEmpty(s: string) {
   return s.trim() !== "";
 }
 
-db.connect().then(async () => {
+initApp().then(async () => {
   const answers = {
     emailDomain: await input({ message: "Email Domain", validate: notEmpty }),
     paymentProviders: await checkbox({

--- a/src/tools/configure.ts
+++ b/src/tools/configure.ts
@@ -1,7 +1,6 @@
 import "module-alias/register";
 
 import { checkbox, input } from "@inquirer/prompts";
-import { getRepository } from "typeorm";
 
 import * as db from "@core/database";
 
@@ -29,7 +28,7 @@ db.connect().then(async () => {
 
   await OptionsService.set("support-email", "support@" + answers.emailDomain);
 
-  await getRepository(Content).update("join", {
+  await db.getRepository(Content).update("join", {
     data: () =>
       `jsonb_set(data, \'{paymentMethods}\', \'${JSON.stringify(
         answers.paymentProviders

--- a/src/tools/configure.ts
+++ b/src/tools/configure.ts
@@ -2,18 +2,18 @@ import "module-alias/register";
 
 import { checkbox, input } from "@inquirer/prompts";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
+import { runApp } from "@core/server";
 
 import OptionsService from "@core/services/OptionsService";
 
 import Content from "@models/Content";
-import { initApp } from "@core/server";
 
 function notEmpty(s: string) {
   return s.trim() !== "";
 }
 
-initApp().then(async () => {
+runApp(async () => {
   const answers = {
     emailDomain: await input({ message: "Email Domain", validate: notEmpty }),
     paymentProviders: await checkbox({
@@ -29,12 +29,10 @@ initApp().then(async () => {
 
   await OptionsService.set("support-email", "support@" + answers.emailDomain);
 
-  await db.getRepository(Content).update("join", {
+  await getRepository(Content).update("join", {
     data: () =>
       `jsonb_set(data, \'{paymentMethods}\', \'${JSON.stringify(
         answers.paymentProviders
       )}\')`
   });
-
-  await db.close();
 });

--- a/src/tools/database/anonymisers/index.ts
+++ b/src/tools/database/anonymisers/index.ts
@@ -1,5 +1,4 @@
 import {
-  createQueryBuilder,
   EntityTarget,
   ObjectLiteral,
   OrderByCondition,
@@ -7,7 +6,7 @@ import {
 } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
-import { getRepository } from "@core/database";
+import { createQueryBuilder, getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 
 import Callout from "@models/Callout";

--- a/src/tools/database/anonymisers/index.ts
+++ b/src/tools/database/anonymisers/index.ts
@@ -1,12 +1,13 @@
 import {
   createQueryBuilder,
   EntityTarget,
-  getRepository,
+  ObjectLiteral,
   OrderByCondition,
   SelectQueryBuilder
 } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 
 import Callout from "@models/Callout";
@@ -63,7 +64,10 @@ function anonymiseItem<T>(
   return newItem;
 }
 
-function writeItems<T>(model: EntityTarget<T>, items: T[]) {
+function writeItems<T extends ObjectLiteral>(
+  model: EntityTarget<T>,
+  items: T[]
+) {
   const [query, params] = createQueryBuilder()
     .insert()
     .into(model)
@@ -126,7 +130,7 @@ async function anonymiseCalloutResponses(
   }
 }
 
-export async function anonymiseModel<T>(
+export async function anonymiseModel<T extends ObjectLiteral>(
   anonymiser: ModelAnonymiser<T>,
   fn: (qb: SelectQueryBuilder<T>) => SelectQueryBuilder<T>,
   valueMap: Map<string, unknown>
@@ -168,7 +172,9 @@ export function clearModels(anonymisers: ModelAnonymiser<unknown>[]) {
   // Reverse order to clear foreign keys correctly
   for (let i = anonymisers.length - 1; i >= 0; i--) {
     console.log(
-      `DELETE FROM "${getRepository(anonymisers[i].model).metadata.tableName}";`
+      `DELETE FROM "${
+        getRepository(anonymisers[i].model as any).metadata.tableName
+      }";`
     );
     console.log(); // Empty params line
   }

--- a/src/tools/database/anonymisers/index.ts
+++ b/src/tools/database/anonymisers/index.ts
@@ -168,13 +168,11 @@ export async function anonymiseModel<T extends ObjectLiteral>(
   }
 }
 
-export function clearModels(anonymisers: ModelAnonymiser<unknown>[]) {
+export function clearModels(anonymisers: ModelAnonymiser<ObjectLiteral>[]) {
   // Reverse order to clear foreign keys correctly
   for (let i = anonymisers.length - 1; i >= 0; i--) {
     console.log(
-      `DELETE FROM "${
-        getRepository(anonymisers[i].model as any).metadata.tableName
-      }";`
+      `DELETE FROM "${getRepository(anonymisers[i].model).metadata.tableName}";`
     );
     console.log(); // Empty params line
   }

--- a/src/tools/database/anonymisers/index.ts
+++ b/src/tools/database/anonymisers/index.ts
@@ -99,7 +99,6 @@ async function anonymiseCalloutResponses(
     );
 
     const responses = await fn(createQueryBuilder(CalloutResponse, "item"))
-      .loadAllRelationIds()
       .andWhere("item.callout = :callout", { callout: callout.slug })
       .orderBy("item.id", "ASC")
       .getMany();
@@ -149,7 +148,6 @@ export async function anonymiseModel<T extends ObjectLiteral>(
 
   for (let i = 0; ; i += 1000) {
     const items = await fn(createQueryBuilder(anonymiser.model, "item"))
-      .loadAllRelationIds()
       .orderBy(orderBy)
       .offset(i)
       .limit(1000)

--- a/src/tools/database/anonymisers/models.ts
+++ b/src/tools/database/anonymisers/models.ts
@@ -122,9 +122,6 @@ function uniqueCode(): string {
   return letter.padStart(2, "A") + (no + "").padStart(3, "0");
 }
 
-// Relations will be strings but the type checker thinks they will be objects
-const relationId = () => uuidv4() as any;
-
 // Model anonymisers
 
 export const calloutsAnonymiser = createModelAnonymiser(Callout);
@@ -133,8 +130,8 @@ export const calloutResponsesAnonymiser = createModelAnonymiser(
   CalloutResponse,
   {
     id: () => uuidv4(),
-    contact: relationId,
-    assignee: relationId,
+    contactId: () => uuidv4(),
+    assigneeId: () => uuidv4(),
     guestName: () => chance.name(),
     guestEmail: () => chance.email({ domain: "example.com", length: 10 })
   }
@@ -144,8 +141,8 @@ export const calloutResponseCommentsAnonymiser = createModelAnonymiser(
   CalloutResponseComment,
   {
     id: () => uuidv4(),
-    response: relationId,
-    contact: relationId,
+    responseId: () => uuidv4(),
+    contactId: () => uuidv4(),
     text: () => chance.paragraph()
   }
 );
@@ -153,8 +150,8 @@ export const calloutResponseCommentsAnonymiser = createModelAnonymiser(
 export const calloutResponseTagsAnonymiser = createModelAnonymiser(
   CalloutResponseTag,
   {
-    response: relationId,
-    tag: relationId
+    responseId: () => uuidv4(),
+    tagId: () => uuidv4()
   }
 );
 
@@ -175,7 +172,7 @@ export const contactAnonymiser = createModelAnonymiser(Contact, {
 });
 
 export const contactProfileAnonymiser = createModelAnonymiser(ContactProfile, {
-  contact: relationId,
+  contactId: () => uuidv4(),
   description: () => chance.sentence(),
   bio: () => chance.paragraph(),
   notes: () => chance.sentence(),
@@ -191,7 +188,7 @@ export const contactProfileAnonymiser = createModelAnonymiser(ContactProfile, {
 });
 
 export const contactRoleAnonymiser = createModelAnonymiser(ContactRole, {
-  contact: relationId
+  contactId: () => uuidv4()
 });
 
 export const emailAnonymiser = createModelAnonymiser(Email);
@@ -218,7 +215,7 @@ export const giftFlowAnonymiser = createModelAnonymiser(GiftFlow, {
     fromName: () => chance.name(),
     fromEmail: () => chance.email({ domain: "fake.beabee.io", length: 10 })
   }),
-  giftee: relationId
+  gifteeId: () => uuidv4()
 });
 
 export const noticesAnonymiser = createModelAnonymiser(Notice);
@@ -228,7 +225,7 @@ export const optionsAnonymiser = createModelAnonymiser(Option);
 export const pageSettingsAnonymiser = createModelAnonymiser(PageSettings);
 
 export const paymentDataAnonymiser = createModelAnonymiser(PaymentData, {
-  contact: relationId,
+  contactId: () => uuidv4(),
   data: createObjectMap<PaymentData["data"]>({
     customerId: randomId(12, "CU"),
     mandateId: randomId(12, "MD"),
@@ -241,16 +238,16 @@ export const paymentDataAnonymiser = createModelAnonymiser(PaymentData, {
 export const paymentsAnonymiser = createModelAnonymiser(Payment, {
   id: () => uuidv4(),
   subscriptionId: randomId(12, "SB"),
-  contact: relationId
+  contactId: () => uuidv4()
 });
 
 export const projectsAnonymiser = createModelAnonymiser(Project, {
-  owner: relationId
+  ownerId: () => uuidv4()
 });
 
 export const projectContactsAnonymiser = createModelAnonymiser(ProjectContact, {
   id: () => uuidv4(),
-  contact: relationId,
+  contactId: () => uuidv4(),
   tag: () => chance.profession()
 });
 
@@ -258,16 +255,16 @@ export const projectEngagmentsAnonymiser = createModelAnonymiser(
   ProjectEngagement,
   {
     id: () => uuidv4(),
-    byContact: relationId,
-    toContact: relationId,
+    byContactId: () => uuidv4(),
+    toContactId: () => uuidv4(),
     notes: () => chance.sentence()
   }
 );
 
 export const referralsAnonymiser = createModelAnonymiser(Referral, {
   id: () => uuidv4(),
-  referrer: relationId,
-  referee: relationId
+  referrerId: () => uuidv4(),
+  refereeId: () => uuidv4()
 });
 
 export const referralsGiftAnonymiser = createModelAnonymiser(ReferralGift, {
@@ -278,14 +275,14 @@ export const resetSecurityFlowAnonymiser = createModelAnonymiser(
   ResetSecurityFlow,
   {
     id: () => uuidv4(),
-    contact: relationId
+    contactId: () => uuidv4()
   }
 );
 
 export const segmentsAnonymiser = createModelAnonymiser(Segment);
 
 export const segmentContactsAnonymiser = createModelAnonymiser(SegmentContact, {
-  contact: relationId
+  contactId: () => uuidv4()
 });
 
 export const segmentOngoingEmailsAnonymiser =

--- a/src/tools/database/anonymisers/models.ts
+++ b/src/tools/database/anonymisers/models.ts
@@ -4,7 +4,7 @@ import {
 } from "@beabee/beabee-common";
 import { Chance } from "chance";
 import crypto from "crypto";
-import { EntityTarget } from "typeorm";
+import { EntityTarget, ObjectLiteral } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
 
 import Email from "@models/Email";
@@ -38,14 +38,14 @@ import ResetSecurityFlow from "@models/ResetSecurityFlow";
 export type PropertyMap<T> = ((prop: T) => T) | ObjectMap<T>;
 export type ObjectMap<T> = { [K in keyof T]?: PropertyMap<T[K]> };
 
-export interface ModelAnonymiser<T> {
+export interface ModelAnonymiser<T extends ObjectLiteral = ObjectLiteral> {
   model: EntityTarget<T>;
   objectMap: ObjectMap<T>;
 }
 
 // Functions to facilitate type checking when creating anonymisers
 
-function createModelAnonymiser<T>(
+function createModelAnonymiser<T extends ObjectLiteral>(
   model: EntityTarget<T>,
   objectMap: ObjectMap<T> = {}
 ): ModelAnonymiser<T> {

--- a/src/tools/database/export-demo.ts
+++ b/src/tools/database/export-demo.ts
@@ -2,7 +2,8 @@ import "module-alias/register";
 
 import { Brackets } from "typeorm";
 
-import * as db from "@core/database";
+import { createQueryBuilder } from "@core/database";
+import { runApp } from "@core/server";
 
 import Contact from "@models/Contact";
 
@@ -64,8 +65,7 @@ async function main() {
     resetSecurityFlowAnonymiser
   ] as ModelAnonymiser[]);
 
-  const contacts = await db
-    .createQueryBuilder(Contact, "item")
+  const contacts = await createQueryBuilder(Contact, "item")
     .select("item.id")
     .orderBy("random()")
     .limit(400)
@@ -82,8 +82,7 @@ async function main() {
     );
   }
 
-  const callouts = await db
-    .createQueryBuilder(Callout, "item")
+  const callouts = await createQueryBuilder(Callout, "item")
     .select("item.slug")
     .orderBy("item.date", "DESC")
     .limit(20)
@@ -100,8 +99,7 @@ async function main() {
     );
   }
 
-  const responses = await db
-    .createQueryBuilder(CalloutResponse, "item")
+  const responses = await createQueryBuilder(CalloutResponse, "item")
     .select("item.id")
     .where("item.calloutSlug IN (:...callouts)", { callouts: calloutSlugs })
     .andWhere(
@@ -133,11 +131,10 @@ async function main() {
   }
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   try {
     await main();
   } catch (err) {
     console.error(err);
   }
-  await db.close();
 });

--- a/src/tools/database/export-demo.ts
+++ b/src/tools/database/export-demo.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { Brackets, ObjectLiteral, createQueryBuilder } from "typeorm";
+import { Brackets } from "typeorm";
 
 import * as db from "@core/database";
 
@@ -64,7 +64,8 @@ async function main() {
     resetSecurityFlowAnonymiser
   ] as ModelAnonymiser[]);
 
-  const contacts = await createQueryBuilder(Contact, "item")
+  const contacts = await db
+    .createQueryBuilder(Contact, "item")
     .select("item.id")
     .orderBy("random()")
     .limit(400)
@@ -81,7 +82,8 @@ async function main() {
     );
   }
 
-  const callouts = await createQueryBuilder(Callout, "item")
+  const callouts = await db
+    .createQueryBuilder(Callout, "item")
     .select("item.slug")
     .orderBy("item.date", "DESC")
     .limit(20)
@@ -98,7 +100,8 @@ async function main() {
     );
   }
 
-  const responses = await createQueryBuilder(CalloutResponse, "item")
+  const responses = await db
+    .createQueryBuilder(CalloutResponse, "item")
     .select("item.id")
     .where("item.calloutSlug IN (:...callouts)", { callouts: calloutSlugs })
     .andWhere(

--- a/src/tools/database/export-demo.ts
+++ b/src/tools/database/export-demo.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 
-import { Brackets, createQueryBuilder } from "typeorm";
+import { Brackets, ObjectLiteral, createQueryBuilder } from "typeorm";
 
 import * as db from "@core/database";
 
@@ -34,18 +34,18 @@ const contactAnonymisers = [
   contactProfileAnonymiser,
   paymentsAnonymiser,
   paymentDataAnonymiser
-] as ModelAnonymiser<unknown>[];
+] as ModelAnonymiser[];
 
 const calloutsAnonymisers = [
   calloutsAnonymiser,
   calloutTagsAnonymiser
-] as ModelAnonymiser<unknown>[];
+] as ModelAnonymiser[];
 
 const calloutResponseAnonymisers = [
   calloutResponsesAnonymiser,
   // calloutResponseCommentsAnonymiser, TODO: make sure contact exists in export
   calloutResponseTagsAnonymiser
-] as ModelAnonymiser<unknown>[];
+] as ModelAnonymiser[];
 
 async function main() {
   const valueMap = new Map<string, unknown>();
@@ -62,7 +62,7 @@ async function main() {
     segmentContactsAnonymiser,
     referralsAnonymiser,
     resetSecurityFlowAnonymiser
-  ]);
+  ] as ModelAnonymiser[]);
 
   const contacts = await createQueryBuilder(Contact, "item")
     .select("item.id")

--- a/src/tools/database/export-demo.ts
+++ b/src/tools/database/export-demo.ts
@@ -131,10 +131,4 @@ async function main() {
   }
 }
 
-runApp(async () => {
-  try {
-    await main();
-  } catch (err) {
-    console.error(err);
-  }
-});
+runApp(main);

--- a/src/tools/database/export.ts
+++ b/src/tools/database/export.ts
@@ -1,7 +1,6 @@
 import "module-alias/register";
-import { ObjectLiteral } from "typeorm";
 
-import * as db from "@core/database";
+import { runApp } from "@core/server";
 
 import * as models from "./anonymisers/models";
 import { anonymiseModel, clearModels } from "./anonymisers";
@@ -47,11 +46,10 @@ async function main() {
   }
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   try {
     await main();
   } catch (err) {
     console.error(err);
   }
-  await db.close();
 });

--- a/src/tools/database/export.ts
+++ b/src/tools/database/export.ts
@@ -1,4 +1,5 @@
 import "module-alias/register";
+import { ObjectLiteral } from "typeorm";
 
 import * as db from "@core/database";
 
@@ -34,7 +35,7 @@ const anonymisers = [
   models.segmentContactsAnonymiser,
   models.segmentOngoingEmailsAnonymiser,
   models.exportItemsAnonymiser // Must be after all exportable items
-] as models.ModelAnonymiser<unknown>[];
+] as models.ModelAnonymiser[];
 
 async function main() {
   const valueMap = new Map<string, unknown>();

--- a/src/tools/database/export.ts
+++ b/src/tools/database/export.ts
@@ -46,10 +46,4 @@ async function main() {
   }
 }
 
-runApp(async () => {
-  try {
-    await main();
-  } catch (err) {
-    console.error(err);
-  }
-});
+runApp(main);

--- a/src/tools/database/import-steady.ts
+++ b/src/tools/database/import-steady.ts
@@ -6,7 +6,7 @@ import {
   NewsletterStatus
 } from "@beabee/beabee-common";
 import { parse } from "csv-parse";
-import { In, getRepository } from "typeorm";
+import { In } from "typeorm";
 
 import * as db from "@core/database";
 import { cleanEmailAddress } from "@core/utils";
@@ -96,7 +96,7 @@ function convertPeriod(period: "annual" | "monthly"): ContributionPeriod {
 }
 
 function getRole(row: SteadyRow): ContactRole {
-  return getRepository(ContactRole).create({
+  return db.getRepository(ContactRole).create({
     type: "member",
     dateAdded: new Date(row.subscribed_at),
     dateExpires: row.expires_at ? new Date(row.expires_at) : null
@@ -233,7 +233,7 @@ async function addNewContact(row: SteadyRow) {
 async function processRows(rows: SteadyRow[]) {
   console.error(`Processing ${rows.length} rows`);
 
-  const existingContacts = await getRepository(Contact).find({
+  const existingContacts = await db.getRepository(Contact).find({
     where: { email: In(rows.map((row) => row.email)) }
   });
 

--- a/src/tools/database/import-steady.ts
+++ b/src/tools/database/import-steady.ts
@@ -8,7 +8,8 @@ import {
 import { parse } from "csv-parse";
 import { In } from "typeorm";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
+import { runApp } from "@core/server";
 import { cleanEmailAddress } from "@core/utils";
 
 import ContactsService from "@core/services/ContactsService";
@@ -96,7 +97,7 @@ function convertPeriod(period: "annual" | "monthly"): ContributionPeriod {
 }
 
 function getRole(row: SteadyRow): ContactRole {
-  return db.getRepository(ContactRole).create({
+  return getRepository(ContactRole).create({
     type: "member",
     dateAdded: new Date(row.subscribed_at),
     dateExpires: row.expires_at ? new Date(row.expires_at) : null
@@ -233,7 +234,7 @@ async function addNewContact(row: SteadyRow) {
 async function processRows(rows: SteadyRow[]) {
   console.error(`Processing ${rows.length} rows`);
 
-  const existingContacts = await db.getRepository(Contact).find({
+  const existingContacts = await getRepository(Contact).find({
     where: { email: In(rows.map((row) => row.email)) }
   });
 
@@ -286,8 +287,7 @@ async function loadRows(): Promise<SteadyRow[]> {
   });
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   const rows = await loadRows();
   await processRows(rows);
-  await db.close();
 });

--- a/src/tools/database/import.ts
+++ b/src/tools/database/import.ts
@@ -1,20 +1,21 @@
 import "module-alias/register";
 
 import readline from "readline";
-import { getManager } from "typeorm";
+
+import { getConnection } from "@core/database";
+import { runApp } from "@core/server";
 
 import config from "@config";
-import * as db from "@core/database";
 
 if (!config.dev) {
   console.error("Can't import to live database");
   process.exit(1);
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   // File format: first line is SQL, second is params (repeated)
   try {
-    await getManager().transaction(async (manager) => {
+    await getConnection().manager.transaction(async (manager) => {
       const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,
@@ -38,6 +39,4 @@ db.connect().then(async () => {
   } catch (err) {
     console.error(err);
   }
-
-  await db.close();
 });

--- a/src/tools/database/import.ts
+++ b/src/tools/database/import.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import readline from "readline";
 
-import { getConnection } from "@core/database";
+import { dataSource } from "@core/database";
 import { runApp } from "@core/server";
 
 import config from "@config";
@@ -15,7 +15,7 @@ if (!config.dev) {
 runApp(async () => {
   // File format: first line is SQL, second is params (repeated)
   try {
-    await getConnection().manager.transaction(async (manager) => {
+    await dataSource.manager.transaction(async (manager) => {
       const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,

--- a/src/tools/database/import.ts
+++ b/src/tools/database/import.ts
@@ -14,29 +14,22 @@ if (!config.dev) {
 
 runApp(async () => {
   // File format: first line is SQL, second is params (repeated)
-  try {
-    await dataSource.manager.transaction(async (manager) => {
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-        terminal: false
-      });
-
-      let query = "";
-      for await (const line of rl) {
-        if (query) {
-          console.log("Running " + query.substring(0, 100) + "...");
-          await manager.query(
-            query,
-            line !== "" ? JSON.parse(line) : undefined
-          );
-          query = "";
-        } else {
-          query = line;
-        }
-      }
+  await dataSource.manager.transaction(async (manager) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false
     });
-  } catch (err) {
-    console.error(err);
-  }
+
+    let query = "";
+    for await (const line of rl) {
+      if (query) {
+        console.log("Running " + query.substring(0, 100) + "...");
+        await manager.query(query, line !== "" ? JSON.parse(line) : undefined);
+        query = "";
+      } else {
+        query = line;
+      }
+    }
+  });
 });

--- a/src/tools/gocardless/migrate-to-stripe.ts
+++ b/src/tools/gocardless/migrate-to-stripe.ts
@@ -4,13 +4,7 @@ import { PaymentMethod, PaymentStatus } from "@beabee/beabee-common";
 import { parse } from "csv-parse";
 import { add, startOfDay, sub } from "date-fns";
 import Stripe from "stripe";
-import {
-  Equal,
-  FindConditions,
-  In,
-  createQueryBuilder,
-  getRepository
-} from "typeorm";
+import { Equal, In, createQueryBuilder } from "typeorm";
 
 import * as db from "@core/database";
 import stripe from "@core/lib/stripe";
@@ -94,11 +88,11 @@ db.connect().then(async () => {
 
   console.log("Found", contacts.length, "contacts");
 
-  const payments = await getRepository(Payment).find({
+  const payments = await db.getRepository(Payment).find({
     where: {
-      contact: In(contacts.map((c) => c.id)),
+      contactId: In(contacts.map((c) => c.id)),
       status: Equal(PaymentStatus.Pending)
-    } as FindConditions<Payment>,
+    },
     loadRelationIds: true
   });
 
@@ -152,7 +146,7 @@ db.connect().then(async () => {
         // We do this directly rather than using updatePaymentMethod as it's not
         // meant for updating payment methods that are already associated with
         // the customer in Stripe
-        await getRepository(PaymentData).update(contact.id, {
+        await db.getRepository(PaymentData).update(contact.id, {
           method: stripeTypeToPaymentMethod(migrationRow.type),
           data: {
             customerId: migrationRow.customer_id,

--- a/src/tools/gocardless/migrate-to-stripe.ts
+++ b/src/tools/gocardless/migrate-to-stripe.ts
@@ -93,14 +93,11 @@ db.connect().then(async () => {
     where: {
       contactId: In(contacts.map((c) => c.id)),
       status: Equal(PaymentStatus.Pending)
-    },
-    loadRelationIds: true
+    }
   });
 
   for (const contact of contacts) {
-    const contactPayments = payments.filter(
-      (p) => (p.contact as any) === contact.id
-    );
+    const contactPayments = payments.filter((p) => p.contactId === contact.id);
 
     const paymentData = contact.paymentData.data as GCPaymentData;
 

--- a/src/tools/gocardless/migrate-to-stripe.ts
+++ b/src/tools/gocardless/migrate-to-stripe.ts
@@ -4,7 +4,7 @@ import { PaymentMethod, PaymentStatus } from "@beabee/beabee-common";
 import { parse } from "csv-parse";
 import { add, startOfDay, sub } from "date-fns";
 import Stripe from "stripe";
-import { Equal, In, createQueryBuilder } from "typeorm";
+import { Equal, In } from "typeorm";
 
 import * as db from "@core/database";
 import stripe from "@core/lib/stripe";
@@ -69,7 +69,8 @@ db.connect().then(async () => {
 
   const migrationData = await loadMigrationData();
 
-  const contacts = await createQueryBuilder(Contact, "contact")
+  const contacts = await db
+    .createQueryBuilder(Contact, "contact")
     // Only select those that are't renewing in the next 5 days
     .innerJoinAndSelect(
       "contact.roles",

--- a/src/tools/mailchimp/sync.ts
+++ b/src/tools/mailchimp/sync.ts
@@ -4,8 +4,9 @@ import { NewsletterStatus } from "@beabee/beabee-common";
 import moment from "moment";
 import { Between } from "typeorm";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
+import { runApp } from "@core/server";
 
 import ContactsService from "@core/services/ContactsService";
 import NewsletterService from "@core/services/NewsletterService";
@@ -30,7 +31,7 @@ async function fetchContacts(
     endDate: actualEndDate
   });
 
-  const memberships = await db.getRepository(ContactRole).find({
+  const memberships = await getRepository(ContactRole).find({
     where: {
       type: "member",
       dateExpires: Between(actualStartDate, actualEndDate)
@@ -78,7 +79,7 @@ async function processContacts(contacts: Contact[]) {
   }
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   const isTest = process.argv[2] === "-n";
   try {
     const [startDate, endDate] = process.argv.slice(isTest ? 3 : 2);
@@ -89,5 +90,4 @@ db.connect().then(async () => {
   } catch (err) {
     log.error(err);
   }
-  await db.close();
 });

--- a/src/tools/mailchimp/sync.ts
+++ b/src/tools/mailchimp/sync.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import { NewsletterStatus } from "@beabee/beabee-common";
 import moment from "moment";
-import { Between, getRepository } from "typeorm";
+import { Between } from "typeorm";
 
 import * as db from "@core/database";
 import { log as mainLogger } from "@core/logging";
@@ -30,12 +30,12 @@ async function fetchContacts(
     endDate: actualEndDate
   });
 
-  const memberships = await getRepository(ContactRole).find({
+  const memberships = await db.getRepository(ContactRole).find({
     where: {
       type: "member",
       dateExpires: Between(actualStartDate, actualEndDate)
     },
-    relations: ["contact", "contact.profile"]
+    relations: { contact: { profile: true } }
   });
   log.info(`Got ${memberships.length} members`);
   return memberships.map(({ contact }) => {

--- a/src/tools/mailchimp/sync.ts
+++ b/src/tools/mailchimp/sync.ts
@@ -81,13 +81,9 @@ async function processContacts(contacts: Contact[]) {
 
 runApp(async () => {
   const isTest = process.argv[2] === "-n";
-  try {
-    const [startDate, endDate] = process.argv.slice(isTest ? 3 : 2);
-    const contacts = await fetchContacts(startDate, endDate);
-    if (!isTest) {
-      await processContacts(contacts);
-    }
-  } catch (err) {
-    log.error(err);
+  const [startDate, endDate] = process.argv.slice(isTest ? 3 : 2);
+  const contacts = await fetchContacts(startDate, endDate);
+  if (!isTest) {
+    await processContacts(contacts);
   }
 });

--- a/src/tools/new-user.ts
+++ b/src/tools/new-user.ts
@@ -4,7 +4,8 @@ import { ContributionType } from "@beabee/beabee-common";
 import { input, password, select } from "@inquirer/prompts";
 import moment from "moment";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
+import { runApp } from "@core/server";
 import { generatePassword, passwordRequirements } from "@core/utils/auth";
 
 import ContactsService from "@core/services/ContactsService";
@@ -20,7 +21,7 @@ function notEmpty(s: string) {
   return s.trim() !== "";
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   const answers = {
     firstname: await input({ message: "First Name", validate: notEmpty }),
     lastname: await input({ message: "Last Name", validate: notEmpty }),
@@ -68,7 +69,7 @@ db.connect().then(async () => {
         break;
     }
 
-    const membership = db.getRepository(ContactRole).create({
+    const membership = getRepository(ContactRole).create({
       type: "member",
       ...(dateAdded && { dateAdded }),
       dateExpires
@@ -77,7 +78,7 @@ db.connect().then(async () => {
   }
 
   if (answers.role != "None") {
-    const admin = db.getRepository(ContactRole).create({
+    const admin = getRepository(ContactRole).create({
       type: answers.role === "Admin" ? "admin" : "superadmin"
     });
     roles.push(admin);
@@ -104,6 +105,4 @@ db.connect().then(async () => {
       `Reset password link: ${config.audience}/auth/set-password/${rpFlow.id}`
     );
   }
-
-  await db.close();
 });

--- a/src/tools/new-user.ts
+++ b/src/tools/new-user.ts
@@ -3,7 +3,6 @@ import "module-alias/register";
 import { ContributionType } from "@beabee/beabee-common";
 import { input, password, select } from "@inquirer/prompts";
 import moment from "moment";
-import { getRepository } from "typeorm";
 
 import * as db from "@core/database";
 import { generatePassword, passwordRequirements } from "@core/utils/auth";
@@ -69,7 +68,7 @@ db.connect().then(async () => {
         break;
     }
 
-    const membership = getRepository(ContactRole).create({
+    const membership = db.getRepository(ContactRole).create({
       type: "member",
       ...(dateAdded && { dateAdded }),
       dateExpires
@@ -78,7 +77,7 @@ db.connect().then(async () => {
   }
 
   if (answers.role != "None") {
-    const admin = getRepository(ContactRole).create({
+    const admin = db.getRepository(ContactRole).create({
       type: answers.role === "Admin" ? "admin" : "superadmin"
     });
     roles.push(admin);

--- a/src/tools/process-segments.ts
+++ b/src/tools/process-segments.ts
@@ -22,16 +22,15 @@ async function processSegment(segment: Segment) {
 
   const matchedContacts = await SegmentService.getSegmentContacts(segment);
 
-  const segmentContacts = (await getRepository(SegmentContact).find({
-    where: { segmentId: segment.id },
-    loadRelationIds: true
-  })) as unknown as WithRelationIds<SegmentContact, "contact">[];
+  const segmentContacts = await getRepository(SegmentContact).find({
+    where: { segmentId: segment.id }
+  });
 
   const newContacts = matchedContacts.filter((m) =>
-    segmentContacts.every((sm) => sm.contact !== m.id)
+    segmentContacts.every((sm) => sm.contactId !== m.id)
   );
   const oldSegmentContacts = segmentContacts.filter((sm) =>
-    matchedContacts.every((m) => m.id !== sm.contact)
+    matchedContacts.every((m) => m.id !== sm.contactId)
   );
 
   log.info(
@@ -56,7 +55,7 @@ async function processSegment(segment: Segment) {
     segment.newsletterTag ||
     outgoingEmails.some((oe) => oe.trigger === "onLeave")
       ? await ContactsService.findByIds(
-          oldSegmentContacts.map((sm) => sm.contact)
+          oldSegmentContacts.map((sm) => sm.contactId)
         )
       : [];
 

--- a/src/tools/process-segments.ts
+++ b/src/tools/process-segments.ts
@@ -101,9 +101,5 @@ async function main(segmentId?: string) {
 }
 
 runApp(async () => {
-  try {
-    await main(process.argv[2]);
-  } catch (error) {
-    log.error("Unexpected error", error);
-  }
+  await main(process.argv[2]);
 });

--- a/src/tools/process-segments.ts
+++ b/src/tools/process-segments.ts
@@ -34,7 +34,7 @@ async function processSegment(segment: Segment) {
     .map((sm) => sm.contactId);
 
   log.info(
-    `Segment ${segment.name} has ${segmentContacts.length} existing contacts, ${newContacts.length} new contacts and ${oldSegmentContacts.length} old contacts`
+    `Segment ${segment.name} has ${segmentContacts.length} existing contacts, ${newContacts.length} new contacts and ${oldSegmentContactIds.length} old contacts`
   );
 
   await getRepository(SegmentContact).delete({

--- a/src/tools/process-segments.ts
+++ b/src/tools/process-segments.ts
@@ -47,7 +47,7 @@ async function processSegment(segment: Segment) {
 
   const outgoingEmails = await db.getRepository(SegmentOngoingEmail).find({
     where: { segmentId: segment.id },
-    relations: ["email"]
+    relations: { email: true }
   });
 
   // Only fetch old contacts if we need to

--- a/src/tools/start-gifts.ts
+++ b/src/tools/start-gifts.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import moment from "moment";
-import { Between, getRepository } from "typeorm";
+import { Between } from "typeorm";
 
 import * as db from "@core/database";
 import { log as mainLogger } from "@core/logging";
@@ -20,7 +20,7 @@ async function main(date: string | undefined) {
     `Processing gifts between ${fromDate.format()} and ${toDate.format()}`
   );
 
-  const giftFlows = await getRepository(GiftFlow).find({
+  const giftFlows = await db.getRepository(GiftFlow).find({
     where: {
       giftForm: { startDate: Between(fromDate.toDate(), toDate.toDate()) },
       completed: true,

--- a/src/tools/start-gifts.ts
+++ b/src/tools/start-gifts.ts
@@ -43,9 +43,5 @@ async function main(date: string | undefined) {
 }
 
 runApp(async () => {
-  try {
-    await main(process.argv[2]);
-  } catch (err) {
-    log.error(err);
-  }
+  await main(process.argv[2]);
 });

--- a/src/tools/start-gifts.ts
+++ b/src/tools/start-gifts.ts
@@ -3,8 +3,9 @@ import "module-alias/register";
 import moment from "moment";
 import { Between } from "typeorm";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
+import { runApp } from "@core/server";
 
 import GiftService from "@core/services/GiftService";
 
@@ -20,7 +21,7 @@ async function main(date: string | undefined) {
     `Processing gifts between ${fromDate.format()} and ${toDate.format()}`
   );
 
-  const giftFlows = await db.getRepository(GiftFlow).find({
+  const giftFlows = await getRepository(GiftFlow).find({
     where: {
       giftForm: { startDate: Between(fromDate.toDate(), toDate.toDate()) },
       completed: true,
@@ -41,11 +42,10 @@ async function main(date: string | undefined) {
   }
 }
 
-db.connect().then(async () => {
+runApp(async () => {
   try {
     await main(process.argv[2]);
   } catch (err) {
     log.error(err);
   }
-  await db.close();
 });

--- a/src/tools/stripe/resync.ts
+++ b/src/tools/stripe/resync.ts
@@ -3,7 +3,8 @@ import "module-alias/register";
 import { PaymentMethod } from "@beabee/beabee-common";
 import { In } from "typeorm";
 
-import * as db from "@core/database";
+import { getRepository } from "@core/database";
+import { runApp } from "@core/server";
 import stripe from "@core/lib/stripe";
 import ContactsService from "@core/services/ContactsService";
 
@@ -30,8 +31,8 @@ async function* fetchInvoices(customerId: string) {
   }
 }
 
-db.connect().then(async () => {
-  const stripePaymentData = (await db.getRepository(PaymentData).find({
+runApp(async () => {
+  const stripePaymentData = (await getRepository(PaymentData).find({
     where: {
       method: In([
         PaymentMethod.StripeBACS,
@@ -117,11 +118,9 @@ db.connect().then(async () => {
     }
 
     if (isDangerMode) {
-      await db.getRepository(PaymentData).save(pd);
+      await getRepository(PaymentData).save(pd);
     } else {
       console.log(pd.cancelledAt, pd.data);
     }
   }
-
-  await db.close();
 });

--- a/src/tools/stripe/resync.ts
+++ b/src/tools/stripe/resync.ts
@@ -39,7 +39,7 @@ db.connect().then(async () => {
         PaymentMethod.StripeSEPA
       ])
     },
-    relations: ["contact"]
+    relations: { contact: true }
   })) as (PaymentData & { data: StripePaymentData })[];
 
   for (const pd of stripePaymentData) {

--- a/src/tools/stripe/resync.ts
+++ b/src/tools/stripe/resync.ts
@@ -1,7 +1,7 @@
 import "module-alias/register";
 
 import { PaymentMethod } from "@beabee/beabee-common";
-import { In, getRepository } from "typeorm";
+import { In } from "typeorm";
 
 import * as db from "@core/database";
 import stripe from "@core/lib/stripe";
@@ -31,7 +31,7 @@ async function* fetchInvoices(customerId: string) {
 }
 
 db.connect().then(async () => {
-  const stripePaymentData = (await getRepository(PaymentData).find({
+  const stripePaymentData = (await db.getRepository(PaymentData).find({
     where: {
       method: In([
         PaymentMethod.StripeBACS,
@@ -117,7 +117,7 @@ db.connect().then(async () => {
     }
 
     if (isDangerMode) {
-      await getRepository(PaymentData).save(pd);
+      await db.getRepository(PaymentData).save(pd);
     } else {
       console.log(pd.cancelledAt, pd.data);
     }

--- a/src/tools/test-users.ts
+++ b/src/tools/test-users.ts
@@ -6,7 +6,7 @@ import {
   PaymentStatus
 } from "@beabee/beabee-common";
 import moment from "moment";
-import { Brackets, createQueryBuilder } from "typeorm";
+import { Brackets } from "typeorm";
 
 import * as db from "@core/database";
 import { getActualAmount } from "@core/utils";
@@ -18,7 +18,8 @@ import Contact from "@models/Contact";
 import PaymentData from "@models/PaymentData";
 
 async function logContact(type: string, conditions: Brackets[]) {
-  const qb = createQueryBuilder(Contact, "m")
+  const qb = db
+    .createQueryBuilder(Contact, "m")
     .innerJoinAndSelect("m.roles", "mp")
     .where("TRUE");
 
@@ -69,27 +70,32 @@ async function logContactVaryContributions(
 async function getFilters() {
   const now = moment.utc();
 
-  const hasScheduledPayments = createQueryBuilder()
+  const hasScheduledPayments = db
+    .createQueryBuilder()
     .subQuery()
     .select("p.contactId")
     .from(Payment, "p")
     .where("p.status = :status", { status: PaymentStatus.Pending });
-  const hasFailedPayments = createQueryBuilder()
+  const hasFailedPayments = db
+    .createQueryBuilder()
     .subQuery()
     .select("p.contactId")
     .from(Payment, "p")
     .where("p.status = 'failed'", { status: PaymentStatus.Failed });
-  const hasSubscription = createQueryBuilder()
+  const hasSubscription = db
+    .createQueryBuilder()
     .subQuery()
     .select("pd.contactId")
     .from(PaymentData, "p")
     .where("pd.subscriptionId IS NOT NULL");
-  const hasCancelled = createQueryBuilder()
+  const hasCancelled = db
+    .createQueryBuilder()
     .subQuery()
     .select("pd.contactId")
     .from(PaymentData, "md")
     .where("md.cancelledAt IS NOT NULL");
-  const isPayingFee = createQueryBuilder()
+  const isPayingFee = db
+    .createQueryBuilder()
     .subQuery()
     .select("md.contactId")
     .from(PaymentData, "md")

--- a/src/tools/test-users.ts
+++ b/src/tools/test-users.ts
@@ -187,11 +187,4 @@ async function main() {
   await logContact("Super admin account", [filters.isSuperAdmin]);
 }
 
-runApp(async () => {
-  console.log();
-  try {
-    await main();
-  } catch (err) {
-    console.error(err);
-  }
-});
+runApp(main);

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -4,10 +4,6 @@ import Contact from "@models/Contact";
 import { CalloutResponseAnswers } from "@models/CalloutResponse";
 
 declare global {
-  type WithRelationIds<E, K extends keyof E> = Omit<E, K> & {
-    [key in K]: string;
-  };
-
   type HTMLElement = never;
   type BufferSource = never;
   type FormData = never;

--- a/src/webhooks/app.ts
+++ b/src/webhooks/app.ts
@@ -2,9 +2,8 @@ import "module-alias/register";
 
 import express, { Handler } from "express";
 
-import * as db from "@core/database";
 import { requestErrorLogger, requestLogger } from "@core/logging";
-import startServer from "@core/server";
+import { initApp, startServer } from "@core/server";
 
 import OptionsService, { OptionKey } from "@core/services/OptionsService";
 
@@ -36,4 +35,4 @@ app.use("/stripe", checkOpt("switch-webhook-stripe"), stripeApp);
 
 app.use(requestErrorLogger);
 
-db.connect().then(() => startServer(app));
+initApp().then(() => startServer(app));

--- a/src/webhooks/app.ts
+++ b/src/webhooks/app.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 
 import express, { Handler } from "express";
 
-import { requestErrorLogger, requestLogger } from "@core/logging";
+import { log, requestErrorLogger, requestLogger } from "@core/logging";
 import { initApp, startServer } from "@core/server";
 
 import OptionsService, { OptionKey } from "@core/services/OptionsService";
@@ -35,4 +35,8 @@ app.use("/stripe", checkOpt("switch-webhook-stripe"), stripeApp);
 
 app.use(requestErrorLogger);
 
-initApp().then(() => startServer(app));
+initApp()
+  .then(() => startServer(app))
+  .catch((err) => {
+    log.error("Error during initialization", err);
+  });

--- a/src/webhooks/handlers/mailchimp.ts
+++ b/src/webhooks/handlers/mailchimp.ts
@@ -119,7 +119,7 @@ async function handleUpdateEmail(data: MCUpdateEmailData) {
 
   log.info(`Update email from ${oldEmail} to ${newEmail}`);
 
-  const contact = await ContactsService.findOne({ email: oldEmail });
+  const contact = await ContactsService.findOneBy({ email: oldEmail });
   if (contact) {
     await ContactsService.updateContact(
       contact,
@@ -140,7 +140,7 @@ async function handleSubscribe(data: MCProfileData) {
     data: { email }
   });
 
-  const contact = await ContactsService.findOne({ email });
+  const contact = await ContactsService.findOneBy({ email });
   if (contact) {
     await ContactsService.updateContactProfile(contact, {
       newsletterStatus: NewsletterStatus.Subscribed
@@ -173,7 +173,7 @@ async function handleUnsubscribe(data: MCProfileData) {
 
   log.info("Unsubscribe " + email);
 
-  const contact = await ContactsService.findOne({ email });
+  const contact = await ContactsService.findOneBy({ email });
   if (contact) {
     await ContactsService.updateContactProfile(contact, {
       newsletterStatus: NewsletterStatus.Unsubscribed
@@ -186,7 +186,7 @@ async function handleCleaned(data: MCCleanedEmailData) {
 
   log.info("Cleaned " + email);
 
-  const contact = await ContactsService.findOne({ email });
+  const contact = await ContactsService.findOneBy({ email });
   if (contact) {
     await ContactsService.updateContactProfile(contact, {
       newsletterStatus: NewsletterStatus.Cleaned
@@ -199,7 +199,7 @@ async function handleUpdateProfile(data: MCProfileData): Promise<boolean> {
 
   log.info("Update profile for " + email);
 
-  const contact = await ContactsService.findOne({ email });
+  const contact = await ContactsService.findOneBy({ email });
   if (contact) {
     const nlContact = await NewsletterService.getNewsletterContact(email);
     await ContactsService.updateContact(contact, {

--- a/src/webhooks/handlers/stripe.ts
+++ b/src/webhooks/handlers/stripe.ts
@@ -3,8 +3,8 @@ import bodyParser from "body-parser";
 import { add } from "date-fns";
 import express from "express";
 import Stripe from "stripe";
-import { getRepository } from "typeorm";
 
+import { getRepository } from "@core/database";
 import { log as mainLogger } from "@core/logging";
 import stripe from "@core/lib/stripe";
 import { wrapAsync } from "@core/utils";
@@ -238,7 +238,7 @@ async function findOrCreatePayment(
     return;
   }
 
-  const payment = await getRepository(Payment).findOne(invoice.id);
+  const payment = await getRepository(Payment).findOneBy({ id: invoice.id });
   if (payment) {
     return payment;
   }


### PR DESCRIPTION
This PR upgrades TypeORM through some breaking changes (especially in [v0.3.0](https://github.com/typeorm/typeorm/releases/tag/0.3.0))

* TYPEORM_ environment variables have been removed in favour of explicitly creating a data source (see `src/core/database.ts`)
* Replaced deprecated `getRepository`, `createQueryBuilder`, etc. with own methods using our data source
* `getRepository(Model).findOne(id)` was previously a short hand for finding by primary key, it was removed in favour of explicitly defining key
  ```ts
  getRepository(Contact).findOne(id) // Old
  getRepository(Contact).findOnBy({id: id}) // New, also adds type safety :)
  ```
* Used lots of type safety where possible, e.g.
  ```ts
  getRepository(Contact).findOne({relations: ["profil"]}) // No compilation error
  getRepository(Contact).findOne({relations: {profil: true}}) // Compilation error :)
  ```
* Added explicit foreign key ID fields for relations. This makes it much easier to query by foreign key IDs and removes a lot of ugly type casting created by using `loadRelationIds`/`loadAllRelationIds` which returned non-type safe results.
  ```ts
  @Entity()
  class Photo {
    @PrimaryColumn()
    id!: string;
  }
  
  @Entity()
  class Post {
    @PrimaryColumn()
    id!: string;
    
    @ManyToOne()
    photo!: Photo
  }

  // Post becomes...
  @Entity()
  class Post {
    @PrimaryColumn()
    id!: string;
    
    @Column()
    photoId!: string; // Explicitly define foreign key field (name must match <field><key>)
    @ManyToOne()
    photo!: Photo
  }