### PR TITLE
fix: chargeDate was actually a string, should be a Date

### DIFF
--- a/src/migrations/1706113195469-ConvertChargeDateToDate.ts
+++ b/src/migrations/1706113195469-ConvertChargeDateToDate.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ConvertChargeDateToDate1706113195469
+  implements MigrationInterface
+{
+  name = "ConvertChargeDateToDate1706113195469";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payment" ALTER COLUMN "chargeDate" TYPE TIMESTAMP`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payment" ALTER COLUMN "chargeDate" TYPE DATE`
+    );
+  }
+}

--- a/src/models/Payment.ts
+++ b/src/models/Payment.ts
@@ -34,7 +34,7 @@ export default class Payment {
   @Column({ type: "real", nullable: true })
   amountRefunded!: number | null;
 
-  @Column({ type: "date" })
+  @Column()
   chargeDate!: Date;
 
   @CreateDateColumn()


### PR DESCRIPTION
It turns out the type of `chargeDate` has been wrong for a while, it was being returned from TypeORM as a string. This is because the date database field doesn't map onto Date (it has no time). This was a legacy of the GoCardless only payment service as payments only have a date in GoCardless, but now we support Stripe we should be using datetimes anyway.