### PR TITLE
feat: validate callout form schema

### DIFF
--- a/src/api/dto/CalloutDto.ts
+++ b/src/api/dto/CalloutDto.ts
@@ -28,6 +28,7 @@ import { CalloutMapSchema, CalloutResponseViewSchema } from "@models/Callout";
 import { CalloutAccess } from "@enums/callout-access";
 
 import { CalloutData } from "@type/callout-data";
+import { CalloutFormDto } from "./CalloutFormDto";
 
 export enum GetCalloutWith {
   Form = "form",
@@ -187,9 +188,8 @@ export class CreateCalloutDto extends BaseCalloutDto {
   @IsString()
   thanksText!: string;
 
-  // TODO: needs validation
-  @IsObject()
-  formSchema!: CalloutFormSchema;
+  @ValidateNested()
+  formSchema!: CalloutFormDto;
 }
 
 export class GetCalloutDto extends BaseCalloutDto {
@@ -217,6 +217,6 @@ export class GetCalloutDto extends BaseCalloutDto {
   responseCount?: number;
 
   @IsOptional()
-  @IsObject()
-  formSchema?: CalloutFormSchema;
+  @ValidateNested()
+  formSchema?: CalloutFormDto;
 }

--- a/src/api/dto/CalloutDto.ts
+++ b/src/api/dto/CalloutDto.ts
@@ -1,4 +1,4 @@
-import { CalloutFormSchema, ItemStatus } from "@beabee/beabee-common";
+import { ItemStatus } from "@beabee/beabee-common";
 import { Type } from "class-transformer";
 import {
   Equals,
@@ -8,7 +8,6 @@ import {
   IsEnum,
   IsIn,
   IsNumber,
-  IsObject,
   IsOptional,
   IsString,
   Max,
@@ -17,6 +16,7 @@ import {
 } from "class-validator";
 
 import { GetExportQuery, GetPaginatedQuery } from "@api/dto/BaseDto";
+import { CalloutFormDto } from "@api/dto/CalloutFormDto";
 import { LinkDto } from "@api/dto/LinkDto";
 import IsSlug from "@api/validators/IsSlug";
 import IsUrl from "@api/validators/IsUrl";
@@ -28,7 +28,6 @@ import { CalloutMapSchema, CalloutResponseViewSchema } from "@models/Callout";
 import { CalloutAccess } from "@enums/callout-access";
 
 import { CalloutData } from "@type/callout-data";
-import { CalloutFormDto } from "./CalloutFormDto";
 
 export enum GetCalloutWith {
   Form = "form",
@@ -189,6 +188,7 @@ export class CreateCalloutDto extends BaseCalloutDto {
   thanksText!: string;
 
   @ValidateNested()
+  @Type(() => CalloutFormDto)
   formSchema!: CalloutFormDto;
 }
 
@@ -218,5 +218,6 @@ export class GetCalloutDto extends BaseCalloutDto {
 
   @IsOptional()
   @ValidateNested()
+  @Type(() => CalloutFormDto)
   formSchema?: CalloutFormDto;
 }

--- a/src/api/dto/CalloutFormDto.ts
+++ b/src/api/dto/CalloutFormDto.ts
@@ -1,0 +1,205 @@
+import {
+  BaseCalloutComponentSchema,
+  CalloutFormSchema,
+  CalloutNavigationSchema,
+  CalloutSlideSchema,
+  InputCalloutComponentSchema,
+  NestableCalloutComponentSchema,
+  RadioCalloutComponentSchema,
+  SelectCalloutComponentSchema
+} from "@beabee/beabee-common";
+import { Type } from "class-transformer";
+import {
+  Equals,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  ValidateNested
+} from "class-validator";
+
+const inputTypes = [
+  "number",
+  "address",
+  "button",
+  "checkbox",
+  "email",
+  "file",
+  "password",
+  "textfield",
+  "textarea"
+] as const;
+const nestedTypes = ["panel", "well", "tabs"] as const;
+const selectTypes = ["select"] as const;
+const radioTypes = ["radio", "selectboxes"] as const;
+
+abstract class BaseCalloutComponentDto implements BaseCalloutComponentSchema {
+  abstract type: string;
+  abstract input?: boolean;
+
+  // TODO
+  [key: string]: unknown;
+
+  @IsString()
+  id!: string;
+
+  @IsString()
+  key!: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  adminOnly?: boolean;
+}
+
+class InputCalloutComponentDto
+  extends BaseCalloutComponentDto
+  implements InputCalloutComponentSchema
+{
+  @IsIn(inputTypes)
+  type!: (typeof inputTypes)[number];
+
+  @Equals(true)
+  input!: true;
+}
+
+class SelectCalloutComponentValueDto {
+  @IsString()
+  label!: string;
+
+  @IsString()
+  value!: string;
+}
+
+class SelectCalloutComponentDataDto {
+  @ValidateNested({ each: true })
+  @Type(() => SelectCalloutComponentValueDto)
+  values!: SelectCalloutComponentValueDto[];
+}
+
+class SelectCalloutComponentDto
+  extends BaseCalloutComponentDto
+  implements SelectCalloutComponentSchema
+{
+  @IsIn(selectTypes)
+  type!: (typeof selectTypes)[number];
+
+  @Equals(true)
+  input!: true;
+
+  @ValidateNested()
+  @Type(() => SelectCalloutComponentDataDto)
+  data!: SelectCalloutComponentDataDto;
+}
+
+class RadioCalloutComponentValueDto {
+  @IsString()
+  label!: string;
+
+  @IsString()
+  value!: string;
+
+  @IsString()
+  nextSlideId!: string;
+}
+
+class RadioCalloutComponentDto
+  extends BaseCalloutComponentDto
+  implements RadioCalloutComponentSchema
+{
+  @IsIn(radioTypes)
+  type!: (typeof radioTypes)[number];
+
+  @Equals(true)
+  input!: true;
+
+  @ValidateNested({ each: true })
+  @Type(() => RadioCalloutComponentValueDto)
+  values!: RadioCalloutComponentValueDto[];
+}
+
+function ComponentType() {
+  return Type(() => BaseCalloutComponentDto, {
+    discriminator: {
+      property: "type",
+      subTypes: [
+        ...nestedTypes.map((type) => ({
+          value: NestableCalloutComponentDto,
+          name: type
+        })),
+        ...inputTypes.map((type) => ({
+          value: InputCalloutComponentDto,
+          name: type
+        })),
+        ...selectTypes.map((type) => ({
+          value: SelectCalloutComponentDto,
+          name: type
+        })),
+        ...radioTypes.map((type) => ({
+          value: RadioCalloutComponentDto,
+          name: type
+        }))
+      ]
+    }
+  });
+}
+
+type CalloutComponentDto =
+  | NestableCalloutComponentDto
+  | InputCalloutComponentDto
+  | SelectCalloutComponentDto
+  | RadioCalloutComponentDto;
+
+class NestableCalloutComponentDto
+  extends BaseCalloutComponentDto
+  implements NestableCalloutComponentSchema
+{
+  @IsIn(nestedTypes)
+  type!: (typeof nestedTypes)[number];
+
+  @Equals(false)
+  input!: false;
+
+  @ValidateNested({ each: true })
+  @ComponentType()
+  components!: CalloutComponentDto[];
+}
+
+class CalloutNavigationDto implements CalloutNavigationSchema {
+  @IsString()
+  prevText!: string;
+
+  @IsString()
+  nextText!: string;
+
+  @IsString()
+  nextSlideId!: string;
+
+  @IsString()
+  submitText!: string;
+}
+
+class CalloutSlideDto implements CalloutSlideSchema {
+  @IsString()
+  id!: string;
+
+  @IsString()
+  title!: string;
+
+  @ValidateNested({ each: true })
+  @ComponentType()
+  components!: CalloutComponentDto[];
+
+  @ValidateNested()
+  @Type(() => CalloutNavigationDto)
+  navigation!: CalloutNavigationSchema;
+}
+
+export class CalloutFormDto implements CalloutFormSchema {
+  @ValidateNested({ each: true })
+  @Type(() => CalloutSlideDto)
+  slides!: CalloutSlideDto[];
+}

--- a/src/api/interceptors/ValidateResponseInterceptor.ts
+++ b/src/api/interceptors/ValidateResponseInterceptor.ts
@@ -36,7 +36,7 @@ export class ValidateResponseInterceptor implements InterceptorInterface {
         whitelist: true,
         forbidUnknownValues: true,
         forbidNonWhitelisted: true,
-        stopAtFirstError: true
+        validationError: { target: false }
       });
       if (errors.length > 0) {
         log.error("Validation failed on response", { errors });


### PR DESCRIPTION
This has been less successful than I hoped. I started adding validation to the form schema but hit against the wall of FormIO component schemas. Unfortunately components have so many possible properties that I don't think I could be fully sure I'm validating it correctly without a lot more work.

So this adds some validation, more than there was before, but disables whitelist validation for components. That means it will check the properties it knows about, but will let other ones through unchecked.