### PR TITLE
fix: use maildev instead of mailhog for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       - 6543:5432 # To connect to the database from the host machine
 
   mail:
-    image: mailhog/mailhog:latest
+    image: maildev/maildev:2.1.0
     ports:
-      - ${MAIL_PORT}:8025
+      - ${MAIL_PORT}:1080
 
   app: *base-app
 


### PR DESCRIPTION
Mailhog hasn't been updated since 2020 and maildev looks more stable. This doesn't really matter for development but this is a partly test to use this tool for dev/demo stages as Mailhog had some security issues in a recent pen test