### PR TITLE
feat: replicate callout in API

### DIFF
--- a/src/api/decorators/TargetUser.ts
+++ b/src/api/decorators/TargetUser.ts
@@ -1,4 +1,3 @@
-import { validateOrReject } from "class-validator";
 import { Request } from "express";
 import {
   NotFoundError,
@@ -9,6 +8,7 @@ import {
 import ContactsService from "@core/services/ContactsService";
 
 import { UUIDParams } from "@api/params/UUIDParams";
+import { validateOrReject } from "@api/utils";
 
 import Contact from "@models/Contact";
 

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,8 +1,8 @@
+import { ValidatorOptions, validate } from "class-validator";
 import { Request } from "express";
-import { BadRequestError } from "routing-controllers";
 
 import Contact from "@models/Contact";
-import { validate } from "class-validator";
+import { BadRequestError } from "routing-controllers";
 
 export function login(req: Request, contact: Contact): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -13,10 +13,26 @@ export function login(req: Request, contact: Contact): Promise<void> {
   });
 }
 
-export async function validateOrReject(data: object) {
-  const errors = await validate(data, {
-    validationError: { target: false, value: false }
+/**
+ * Validate an object using the same base options as the main API validator
+ * @param object The object
+ * @param validationOptions Other validation options
+ */
+export async function validateOrReject(
+  object: object,
+  validationOptions?: ValidatorOptions
+): Promise<void> {
+  const errors = await validate(object, {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    forbidUnknownValues: true,
+    validationError: {
+      target: false,
+      value: false
+    },
+    ...validationOptions
   });
+
   if (errors.length > 0) {
     const error: any = new BadRequestError(
       `Invalid data, check 'errors' property for more info`

--- a/src/api/validators/IsVariantsObject.ts
+++ b/src/api/validators/IsVariantsObject.ts
@@ -1,9 +1,6 @@
-import {
-  ValidateBy,
-  ValidationOptions,
-  buildMessage,
-  validateOrReject
-} from "class-validator";
+import { ValidateBy, ValidationOptions, buildMessage } from "class-validator";
+
+import { validateOrReject } from "@api/utils";
 
 async function isVariantsObject(value: unknown): Promise<boolean> {
   if (typeof value !== "object" || value === null) {

--- a/src/models/Callout.ts
+++ b/src/models/Callout.ts
@@ -11,6 +11,7 @@ import { CalloutAccess } from "@enums/callout-access";
 
 import ItemWithStatus from "./ItemWithStatus";
 import type CalloutResponse from "./CalloutResponse";
+import type CalloutTag from "./CalloutTag";
 import type CalloutVariant from "./CalloutVariant";
 
 import { CalloutResponseViewSchema } from "@type/callout-response-view-schema";
@@ -58,6 +59,9 @@ export default class Callout extends ItemWithStatus {
 
   @Column({ nullable: true })
   responsePassword?: string;
+
+  @OneToMany("CalloutTag", "callout")
+  tags!: CalloutTag[];
 
   @OneToMany("CalloutVariant", "callout")
   variants!: CalloutVariant[];


### PR DESCRIPTION
Add a new API endpoint to use copy from another callout when creating a new one, allowing easy duplication of callouts.