### PR TITLE
feat(contact-filters): contact callout response filters

### DIFF
--- a/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -68,16 +68,13 @@ export abstract class BaseCalloutResponseTransformer<
   protected async transformFilters(
     query: GetOptsDto & PaginatedQuery
   ): Promise<
-    [
-      Partial<Filters<CalloutResponseFilterName>>,
-      FilterHandlers<CalloutResponseFilterName>
-    ]
+    [Partial<Filters<CalloutResponseFilterName>>, FilterHandlers<string>]
   > {
     // If looking for responses for a particular callout then add answer filtering
     const filters = query.callout
       ? getCalloutFilters(query.callout.formSchema)
       : {};
-    return [filters, { answers: individualAnswerFilterHandler }];
+    return [filters, { "answers.": individualAnswerFilterHandler }];
   }
 
   protected transformQuery<T extends GetOptsDto & PaginatedQuery>(

--- a/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -116,7 +116,7 @@ const answerArrayOperators: Partial<
 };
 
 const individualAnswerFilterHandler: FilterHandler = (qb, args) => {
-  const answerField = `${args.fieldPrefix}answers -> :s -> :k`;
+  const answerField = `${args.fieldPrefix}answers -> :slideId -> :answerKey`;
 
   if (args.type === "array") {
     const operatorFn = answerArrayOperators[args.operator];
@@ -138,12 +138,11 @@ const individualAnswerFilterHandler: FilterHandler = (qb, args) => {
     qb.where(args.whereFn(`(${answerField})::${cast}`));
   } else {
     // Extract as text instead of JSONB (note ->> instead of ->)
-    qb.where(args.whereFn(`${args.fieldPrefix}answers -> :s ->> :k`));
+    qb.where(
+      args.whereFn(`${args.fieldPrefix}answers -> :slideId ->> :answerKey`)
+    );
   }
 
   const [_, slideId, answerKey] = args.field.split(".");
-  return {
-    s: slideId,
-    k: answerKey
-  };
+  return { slideId, answerKey };
 };

--- a/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -74,20 +74,10 @@ export abstract class BaseCalloutResponseTransformer<
     ]
   > {
     // If looking for responses for a particular callout then add answer filtering
-    if (query.callout) {
-      const answerFilters = getCalloutFilters(query.callout.formSchema);
-      // All handled by the same field handler
-      const answerFilterHandlers = Object.fromEntries(
-        Object.keys(answerFilters).map((field) => [
-          field,
-          individualAnswerFilterHandler
-        ])
-      );
-
-      return [answerFilters, answerFilterHandlers];
-    } else {
-      return [{}, {}];
-    }
+    const filters = query.callout
+      ? getCalloutFilters(query.callout.formSchema)
+      : {};
+    return [filters, { answers: individualAnswerFilterHandler }];
   }
 
   protected transformQuery<T extends GetOptsDto & PaginatedQuery>(

--- a/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -53,7 +53,7 @@ export abstract class BaseCalloutResponseTransformer<
         .from(CalloutResponseTag, "crt");
 
       if (args.operator === "contains" || args.operator === "not_contains") {
-        subQb.where(args.suffixFn("crt.tag = :a"));
+        subQb.where(args.suffixFn("crt.tag = :valueA"));
       }
 
       const inOp =
@@ -106,8 +106,8 @@ export abstract class BaseCalloutResponseTransformer<
 const answerArrayOperators: Partial<
   Record<RuleOperator, (field: string) => string>
 > = {
-  contains: (field) => `(${field} -> :a)::boolean`,
-  not_contains: (field) => `NOT (${field} -> :a)::boolean`,
+  contains: (field) => `(${field} -> :valueA)::boolean`,
+  not_contains: (field) => `NOT (${field} -> :valueA)::boolean`,
   is_empty: (field) => `NOT jsonb_path_exists(${field}, '$.* ? (@ == true)')`,
   is_not_empty: (field) => `jsonb_path_exists(${field}, '$.* ? (@ == true)')`
 };

--- a/src/api/transformers/BaseCalloutResponseTransformer.ts
+++ b/src/api/transformers/BaseCalloutResponseTransformer.ts
@@ -65,12 +65,14 @@ export abstract class BaseCalloutResponseTransformer<
     }
   };
 
-  protected transformFilters(
+  protected async transformFilters(
     query: GetOptsDto & PaginatedQuery
-  ): [
-    Partial<Filters<CalloutResponseFilterName>>,
-    FilterHandlers<CalloutResponseFilterName>
-  ] {
+  ): Promise<
+    [
+      Partial<Filters<CalloutResponseFilterName>>,
+      FilterHandlers<CalloutResponseFilterName>
+    ]
+  > {
     // If looking for responses for a particular callout then add answer filtering
     if (query.callout) {
       const answerFilters = getCalloutFilters(query.callout.formSchema);

--- a/src/api/transformers/BaseContactTransformer.ts
+++ b/src/api/transformers/BaseContactTransformer.ts
@@ -165,7 +165,9 @@ const calloutResponseFilterHandler: FilterHandler = (qb, args) => {
     field: answerFields.join(".")
   });
 
-  subQb.andWhere(args.addParamSuffix(`item.calloutId = :calloutId`));
+  subQb
+    .andWhere(args.addParamSuffix("item.calloutId = :calloutId"))
+    .andWhere("item.contactId IS NOT NULL");
 
   qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
 

--- a/src/api/transformers/BaseContactTransformer.ts
+++ b/src/api/transformers/BaseContactTransformer.ts
@@ -1,0 +1,101 @@
+import { ContactFilterName, contactFilters } from "@beabee/beabee-common";
+import { Brackets } from "typeorm";
+
+import { createQueryBuilder } from "@core/database";
+
+import { BaseTransformer } from "@api/transformers/BaseTransformer";
+
+import Contact from "@models/Contact";
+import ContactProfile from "@models/ContactProfile";
+import ContactRole from "@models/ContactRole";
+import PaymentData from "@models/PaymentData";
+
+import { FilterHandler, FilterHandlers } from "@type/filter-handlers";
+
+export abstract class BaseContactTransformer<
+  GetDto,
+  GetOptsDto
+> extends BaseTransformer<Contact, GetDto, ContactFilterName, GetOptsDto> {
+  protected model = Contact;
+  protected filters = contactFilters;
+  protected filterHandlers: FilterHandlers<ContactFilterName> = {
+    deliveryOptIn: profileField("deliveryOptIn"),
+    newsletterStatus: profileField("newsletterStatus"),
+    tags: profileField("tags"),
+    activePermission,
+    activeMembership: activePermission,
+    membershipStarts: membershipField("dateAdded"),
+    membershipExpires: membershipField("dateExpires"),
+    contributionCancelled: paymentDataField("cancelledAt"),
+    manualPaymentSource: (qb, args) => {
+      paymentDataField("data ->> 'source'")(qb, args);
+      qb.andWhere(`${args.fieldPrefix}contributionType = 'Manual'`);
+    }
+  };
+}
+
+// Field handlers
+
+function membershipField(field: keyof ContactRole): FilterHandler {
+  return (qb, args) => {
+    const subQb = createQueryBuilder()
+      .subQuery()
+      .select(`cr.contactId`)
+      .from(ContactRole, "cr")
+      .where(`cr.type = 'member'`)
+      .andWhere(args.whereFn(`cr.${field}`));
+
+    qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+  };
+}
+
+function profileField(field: keyof ContactProfile): FilterHandler {
+  return (qb, args) => {
+    const subQb = createQueryBuilder()
+      .subQuery()
+      .select(`profile.contactId`)
+      .from(ContactProfile, "profile")
+      .where(args.whereFn(`profile.${field}`));
+
+    qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+  };
+}
+
+const activePermission: FilterHandler = (qb, args) => {
+  const roleType = args.field === "activeMembership" ? "member" : args.value[0];
+
+  const isIn =
+    args.field === "activeMembership"
+      ? (args.value[0] as boolean)
+      : args.operator === "equal";
+
+  const subQb = createQueryBuilder()
+    .subQuery()
+    .select(`cr.contactId`)
+    .from(ContactRole, "cr")
+    .where(`cr.type = '${roleType}'`)
+    .andWhere(`cr.dateAdded <= :now`)
+    .andWhere(
+      new Brackets((qb) => {
+        qb.where(`cr.dateExpires IS NULL`).orWhere(`cr.dateExpires > :now`);
+      })
+    );
+
+  if (isIn) {
+    qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+  } else {
+    qb.where(`${args.fieldPrefix}id NOT IN ${subQb.getQuery()}`);
+  }
+};
+
+function paymentDataField(field: string): FilterHandler {
+  return (qb, args) => {
+    const subQb = createQueryBuilder()
+      .subQuery()
+      .select(`pd.contactId`)
+      .from(PaymentData, "pd")
+      .where(args.whereFn(`pd.${field}`));
+
+    qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+  };
+}

--- a/src/api/transformers/BaseTransformer.ts
+++ b/src/api/transformers/BaseTransformer.ts
@@ -67,10 +67,10 @@ export abstract class BaseTransformer<
    * @param auth The authentication info
    * @returns New filters and filter handlers
    */
-  protected transformFilters(
+  protected async transformFilters(
     query: Query,
     auth: AuthInfo | undefined
-  ): [Partial<Filters<FilterName>>, FilterHandlers<FilterName>] {
+  ): Promise<[Partial<Filters<FilterName>>, FilterHandlers<FilterName>]> {
     return [{}, {}];
   }
 
@@ -116,10 +116,10 @@ export abstract class BaseTransformer<
    * @param query The query
    * @param auth The contact who is requesting the results
    */
-  protected preFetch<T extends Query>(
+  protected async preFetch<T extends Query>(
     query: T,
     auth: AuthInfo | undefined
-  ): [T, Filters<FilterName>, FilterHandlers<FilterName>] {
+  ): Promise<[T, Filters<FilterName>, FilterHandlers<FilterName>]> {
     if (
       this.allowedRoles &&
       !this.allowedRoles.some((r) => auth?.roles.includes(r))
@@ -127,7 +127,7 @@ export abstract class BaseTransformer<
       throw new UnauthorizedError();
     }
 
-    const [filters, filterHandlers] = this.transformFilters(query, auth);
+    const [filters, filterHandlers] = await this.transformFilters(query, auth);
 
     return [
       this.transformQuery(query, auth),
@@ -147,7 +147,7 @@ export abstract class BaseTransformer<
     auth: AuthInfo | undefined,
     query_: Query
   ): Promise<PaginatedDto<GetDto>> {
-    const [query, filters, filterHandlers] = this.preFetch(query_, auth);
+    const [query, filters, filterHandlers] = await this.preFetch(query_, auth);
 
     const limit = query.limit || 50;
     const offset = query.offset || 0;

--- a/src/api/transformers/CalloutResponseTransformer.ts
+++ b/src/api/transformers/CalloutResponseTransformer.ts
@@ -158,7 +158,7 @@ export class CalloutResponseTransformer extends BaseCalloutResponseTransformer<
     auth: AuthInfo | undefined,
     query: BatchUpdateCalloutResponseDto
   ): Promise<number> {
-    const [query2, filters, filterHandlers] = this.preFetch(query, auth);
+    const [query2, filters, filterHandlers] = await this.preFetch(query, auth);
 
     const { tagUpdates, responseUpdates } = getUpdateData(query2.updates);
     const result = await batchUpdate(

--- a/src/api/transformers/CalloutTransformer.ts
+++ b/src/api/transformers/CalloutTransformer.ts
@@ -43,12 +43,20 @@ class CalloutTransformer extends BaseTransformer<
   protected model = Callout;
   protected modelIdField = "id";
   protected filters = calloutFilters;
-  protected filterHandlers = filterHandlers;
+  protected filterHandlers: FilterHandlers<CalloutFilterName> = {
+    status: statusFilterHandler,
+    title: (qb, args) => {
+      // Filter by variant title
+      qb.where(args.whereFn("cvd.title"));
+    }
+  };
 
-  protected transformFilters(
+  protected async transformFilters(
     query: GetCalloutOptsDto & PaginatedQuery,
     auth: AuthInfo | undefined
-  ): [Partial<Filters<CalloutFilterName>>, FilterHandlers<CalloutFilterName>] {
+  ): Promise<
+    [Partial<Filters<CalloutFilterName>>, FilterHandlers<CalloutFilterName>]
+  > {
     return [
       {},
       {
@@ -276,13 +284,5 @@ class CalloutTransformer extends BaseTransformer<
     }
   }
 }
-
-const filterHandlers: FilterHandlers<CalloutFilterName> = {
-  status: statusFilterHandler,
-  title: (qb, args) => {
-    // Filter by variant title
-    qb.where(args.whereFn("cvd.title"));
-  }
-};
 
 export default new CalloutTransformer();

--- a/src/api/transformers/CalloutTransformer.ts
+++ b/src/api/transformers/CalloutTransformer.ts
@@ -47,7 +47,7 @@ class CalloutTransformer extends BaseTransformer<
     status: statusFilterHandler,
     title: (qb, args) => {
       // Filter by variant title
-      qb.where(args.whereFn("cvd.title"));
+      qb.where(args.convertToWhereClause("cvd.title"));
     }
   };
 
@@ -79,7 +79,7 @@ class CalloutTransformer extends BaseTransformer<
             .select("cr.calloutId")
             .distinctOn(["cr.calloutId"])
             .from(CalloutResponse, "cr")
-            .where(args.whereFn(`cr.contactId`))
+            .where(args.convertToWhereClause(`cr.contactId`))
             .orderBy("cr.calloutId");
 
           qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);

--- a/src/api/transformers/ContactExporter.ts
+++ b/src/api/transformers/ContactExporter.ts
@@ -1,8 +1,4 @@
-import {
-  ContactFilterName,
-  RoleType,
-  contactFilters
-} from "@beabee/beabee-common";
+import { RoleType } from "@beabee/beabee-common";
 import { stringify } from "csv-stringify/sync";
 import { SelectQueryBuilder } from "typeorm";
 
@@ -10,23 +6,16 @@ import { getMembershipStatus } from "@core/services/PaymentService";
 
 import { GetExportQuery } from "@api/dto/BaseDto";
 import { ExportContactDto } from "@api/dto/ContactDto";
-import { BaseTransformer } from "@api/transformers/BaseTransformer";
-import ContactTransformer from "@api/transformers/ContactTransformer";
 
 import Contact from "@models/Contact";
 
 import { AuthInfo } from "@type/auth-info";
+import { BaseContactTransformer } from "./BaseContactTransformer";
 
-class ContactExporter extends BaseTransformer<
-  Contact,
+class ContactExporter extends BaseContactTransformer<
   ExportContactDto,
-  ContactFilterName,
   GetExportQuery
 > {
-  protected model = Contact;
-  protected filters = contactFilters;
-  protected filterHandlers = ContactTransformer.filterHandlers;
-
   protected allowedRoles: RoleType[] = ["admin"];
 
   convert(contact: Contact): ExportContactDto {

--- a/src/api/utils/rules.ts
+++ b/src/api/utils/rules.ts
@@ -43,8 +43,8 @@ import Contact from "@models/Contact";
 // Operator definitions
 
 const equalityOperatorsWhere = {
-  equal: (field: string) => `${field} = :a`,
-  not_equal: (field: string) => `${field} <> :a`
+  equal: (field: string) => `${field} = :valueA`,
+  not_equal: (field: string) => `${field} <> :valueA`
 };
 
 const nullableOperatorsWhere = {
@@ -53,8 +53,8 @@ const nullableOperatorsWhere = {
 };
 
 const blobOperatorsWhere = {
-  contains: (field: string) => `${field} ILIKE '%' || :a || '%'`,
-  not_contains: (field: string) => `${field} NOT ILIKE '%' || :a || '%'`,
+  contains: (field: string) => `${field} ILIKE '%' || :valueA || '%'`,
+  not_contains: (field: string) => `${field} NOT ILIKE '%' || :valueA || '%'`,
   is_empty: (field: string) => `${field} = ''`,
   is_not_empty: (field: string) => `${field} <> ''`
 };
@@ -62,12 +62,12 @@ const blobOperatorsWhere = {
 const numericOperatorsWhere = {
   ...equalityOperatorsWhere,
   ...nullableOperatorsWhere,
-  less: (field: string) => `${field} < :a`,
-  less_or_equal: (field: string) => `${field} <= :a`,
-  greater: (field: string) => `${field} > :a`,
-  greater_or_equal: (field: string) => `${field} >= :a`,
-  between: (field: string) => `${field} BETWEEN :a AND :b`,
-  not_between: (field: string) => `${field} NOT BETWEEN :a AND :b`
+  less: (field: string) => `${field} < :valueA`,
+  less_or_equal: (field: string) => `${field} <= :valueA`,
+  greater: (field: string) => `${field} > :valueA`,
+  greater_or_equal: (field: string) => `${field} >= :valueA`,
+  between: (field: string) => `${field} BETWEEN :valueA AND :valueB`,
+  not_between: (field: string) => `${field} NOT BETWEEN :valueA AND :valueB`
 };
 
 function withOperators<T extends FilterType>(
@@ -87,10 +87,10 @@ const operatorsWhereByType: Record<
   text: withOperators("text", {
     ...equalityOperatorsWhere,
     ...blobOperatorsWhere,
-    begins_with: (field) => `${field} ILIKE :a || '%'`,
-    not_begins_with: (field) => `${field} NOT ILIKE :a || '%'`,
-    ends_with: (field) => `${field} ILIKE '%' || :a`,
-    not_ends_with: (field) => `${field} NOT ILIKE '%' || :a`
+    begins_with: (field) => `${field} ILIKE :valueA || '%'`,
+    not_begins_with: (field) => `${field} NOT ILIKE :valueA || '%'`,
+    ends_with: (field) => `${field} ILIKE '%' || :valueA`,
+    not_ends_with: (field) => `${field} NOT ILIKE '%' || :valueA`
   }),
   blob: withOperators("blob", blobOperatorsWhere),
   date: withOperators("date", numericOperatorsWhere),
@@ -100,8 +100,8 @@ const operatorsWhereByType: Record<
     equal: equalityOperatorsWhere.equal
   }),
   array: withOperators("array", {
-    contains: (field) => `${field} ? :a`,
-    not_contains: (field) => `${field} ? :a = FALSE`,
+    contains: (field) => `${field} ? :valueA`,
+    not_contains: (field) => `${field} ? :valueA = FALSE`,
     is_empty: (field) => `${field} ->> 0 IS NULL`,
     is_not_empty: (field) => `${field} ->> 0 IS NOT NULL`
   }),
@@ -246,8 +246,8 @@ export function convertRulesToWhereClause(
       const [fieldFn, value] = prepareRule(rule, contact);
 
       // Add values as params
-      params["a" + suffix] = value[0];
-      params["b" + suffix] = value[1];
+      params["valueA" + suffix] = value[0];
+      params["valueB" + suffix] = value[1];
 
       // Add suffixes to parameters but avoid replacing casts e.g. ::boolean
       const suffixFn = (field: string) =>

--- a/src/api/utils/rules.ts
+++ b/src/api/utils/rules.ts
@@ -242,7 +242,16 @@ export function convertRulesToWhereClause<Field extends string>(
       const suffixFn = (field: string) =>
         field.replace(/[^:]:[a-z]/g, "$&" + suffix);
 
-      const filterHandler = filterHandlers?.[rule.field] || simpleFilterHandler;
+      let filterHandler = filterHandlers?.[rule.field];
+      // See if there is a root field handler if the field is nested
+      if (!filterHandler && rule.field.includes(".")) {
+        const [field] = rule.field.split(".", 2);
+        filterHandler = filterHandlers?.[field as Field]; // TODO: fix type
+      }
+      if (!filterHandler) {
+        filterHandler = simpleFilterHandler;
+      }
+
       const extraParams = filterHandler(qb, {
         fieldPrefix,
         field: rule.field,

--- a/src/api/utils/rules.ts
+++ b/src/api/utils/rules.ts
@@ -238,9 +238,9 @@ export function convertRulesToWhereClause<Field extends string>(
       params["a" + suffix] = value[0];
       params["b" + suffix] = value[1];
 
-      // Replace :[a-z] but avoid replacing casts e.g. ::boolean
+      // Add suffixes to parameters but avoid replacing casts e.g. ::boolean
       const suffixFn = (field: string) =>
-        field.replace(/[^:]:[a-z]/g, "$&" + suffix);
+        field.replace(/[^:]:[a-zA-Z]+/g, "$&" + suffix);
 
       let filterHandler = filterHandlers?.[rule.field];
       // See if there is a root field handler if the field is nested

--- a/src/type/filter-handlers.ts
+++ b/src/type/filter-handlers.ts
@@ -11,8 +11,8 @@ export type FilterHandler = (
     field: string;
     operator: RuleOperator;
     value: RichRuleValue[];
-    whereFn: (field: string) => string;
-    suffixFn: (field: string) => string;
+    convertToWhereClause: (field: string) => string;
+    addParamSuffix: (field: string) => string;
   }
 ) => void | Record<string, unknown>;
 


### PR DESCRIPTION
This PR adds the ability to filter contacts by their answers to a callout. An example of a filter rule is:
```json
{
  "field": "callouts.<calloutId>.responses.answers.<slideId>.<componentId>",
  "operator": "equal",
  "value": ["test"]
}
```

The filter fields are exactly the same as those already supported for callout response filtering, but with the prefix `callouts.<calloutId>.responses`. Indeed it reuses the same code, the contact field handler strips the prefix and delegates the filtering logic to `individualAnswerFilterHandler`.



This PR also includes the following refactoring:
* To support the changes `BaseTransformer.transformFilters` has become an async function
* `BaseContactTransformer` as a new base class for `ContactTransformer` and `ContactExporter`. This reduces duplication and a similar pattern is already used for `CalloutResponseTransformer` and `CalloutResponseExporter`.
* I tried to make the code which converts filter rules to SQL slightly more legible (although it still needs more work), namely by giving methods and query parameters more useful names (e.g. `:a` -> `:valueA`, `suffixFn` -> `addParamSuffix`)

