### PR TITLE
refactor(contribution): rename PaymentData to ContactContribution

### DIFF
--- a/src/api/transformers/BaseContactTransformer.ts
+++ b/src/api/transformers/BaseContactTransformer.ts
@@ -17,7 +17,7 @@ import { BaseTransformer } from "@api/transformers/BaseTransformer";
 import Contact from "@models/Contact";
 import ContactProfile from "@models/ContactProfile";
 import ContactRole from "@models/ContactRole";
-import PaymentData from "@models/PaymentData";
+import ContactContribution from "@models/ContactContribution";
 
 import { FilterHandler, FilterHandlers } from "@type/filter-handlers";
 import Callout from "@models/Callout";
@@ -47,9 +47,9 @@ export abstract class BaseContactTransformer<
     activeMembership: activePermission,
     membershipStarts: membershipField("dateAdded"),
     membershipExpires: membershipField("dateExpires"),
-    contributionCancelled: paymentDataField("cancelledAt"),
+    contributionCancelled: contributionField("cancelledAt"),
     manualPaymentSource: (qb, args) => {
-      paymentDataField("data ->> 'source'")(qb, args);
+      contributionField("data ->> 'source'")(qb, args);
       qb.andWhere(`${args.fieldPrefix}contributionType = 'Manual'`);
     }
   };
@@ -112,13 +112,13 @@ function profileField(field: keyof ContactProfile): FilterHandler {
   };
 }
 
-function paymentDataField(field: string): FilterHandler {
+function contributionField(field: string): FilterHandler {
   return (qb, { fieldPrefix, convertToWhereClause }) => {
     const subQb = createQueryBuilder()
       .subQuery()
-      .select(`pd.contactId`)
-      .from(PaymentData, "pd")
-      .where(convertToWhereClause(`pd.${field}`));
+      .select(`cc.contactId`)
+      .from(ContactContribution, "cc")
+      .where(convertToWhereClause(`cc.${field}`));
 
     qb.where(`${fieldPrefix}id IN ${subQb.getQuery()}`);
   };

--- a/src/api/transformers/ContactExporter.ts
+++ b/src/api/transformers/ContactExporter.ts
@@ -31,7 +31,7 @@ class ContactExporter extends BaseContactTransformer<
       ContributionPeriod: contact.contributionPeriod,
       ContributionDescription: contact.contributionDescription,
       ContributionCancelled:
-        contact.paymentData.cancelledAt?.toISOString() || "",
+        contact.contribution.cancelledAt?.toISOString() || "",
       MembershipStarts: contact.membership?.dateAdded.toISOString() || "",
       MembershipExpires: contact.membership?.dateExpires?.toISOString() || "",
       MembershipStatus: getMembershipStatus(contact),
@@ -51,7 +51,7 @@ class ContactExporter extends BaseContactTransformer<
     qb.orderBy(`${fieldPrefix}joined`);
     qb.leftJoinAndSelect(`${fieldPrefix}roles`, "roles");
     qb.leftJoinAndSelect(`${fieldPrefix}profile`, "profile");
-    qb.leftJoinAndSelect(`${fieldPrefix}paymentData`, "pd");
+    qb.leftJoinAndSelect(`${fieldPrefix}contribution`, "contribution");
   }
 
   async export(

--- a/src/api/transformers/ContactTransformer.ts
+++ b/src/api/transformers/ContactTransformer.ts
@@ -58,7 +58,7 @@ class ContactTransformer extends BaseContactTransformer<
         roles: contact.roles.map(ContactRoleTransformer.convert)
       }),
       ...(opts?.with?.includes(GetContactWith.Contribution) && {
-        contribution: contact.contribution
+        contribution: contact.contributionInfo
       })
     };
   }
@@ -137,7 +137,7 @@ class ContactTransformer extends BaseContactTransformer<
         throw new Error("Cannot fetch contribution for multiple contacts");
       }
 
-      contacts[0].contribution = await PaymentService.getContributionInfo(
+      contacts[0].contributionInfo = await PaymentService.getContributionInfo(
         contacts[0]
       );
     }

--- a/src/apps/tools/apps/exports/exports/ActiveMembersExport.ts
+++ b/src/apps/tools/apps/exports/exports/ActiveMembersExport.ts
@@ -3,7 +3,7 @@ import { Brackets, SelectQueryBuilder } from "typeorm";
 import { createQueryBuilder } from "@core/database";
 import { Param } from "@core/utils/params";
 
-import PaymentData from "@models/PaymentData";
+import ContactContribution from "@models/ContactContribution";
 import Contact from "@models/Contact";
 
 import BaseExport, { ExportResult } from "./BaseExport";
@@ -45,8 +45,8 @@ export default class ActiveMembersExport extends BaseExport<Contact> {
 
     if (this.ex!.params?.hasActiveSubscription) {
       query
-        .innerJoin(PaymentData, "pd", "pd.contactId = m.id")
-        .andWhere("pd.data ->> 'subscriptionId' IS NOT NULL");
+        .innerJoin(ContactContribution, "cc", "cc.contactId = m.id")
+        .andWhere("cc.data ->> 'subscriptionId' IS NOT NULL");
     }
 
     return query;

--- a/src/core/providers/payment/GCProvider.ts
+++ b/src/core/providers/payment/GCProvider.ts
@@ -18,7 +18,7 @@ import { PaymentProvider, UpdateContributionResult } from ".";
 import { CompletedPaymentFlow } from "@core/providers/payment-flow";
 
 import Contact from "@models/Contact";
-import { GCPaymentData } from "@models/PaymentData";
+import { GCPaymentData } from "@models/ContactContribution";
 
 import NoPaymentMethod from "@api/errors/NoPaymentMethod";
 

--- a/src/core/providers/payment/ManualProvider.ts
+++ b/src/core/providers/payment/ManualProvider.ts
@@ -1,6 +1,6 @@
 import { PaymentForm } from "@core/utils";
 import Contact from "@models/Contact";
-import { ManualPaymentData } from "@models/PaymentData";
+import { ManualPaymentData } from "@models/ContactContribution";
 import { PaymentProvider, UpdateContributionResult } from ".";
 import { CompletedPaymentFlow } from "../payment-flow";
 import { ContributionInfo } from "@type/contribution-info";

--- a/src/core/providers/payment/StripeProvider.ts
+++ b/src/core/providers/payment/StripeProvider.ts
@@ -17,7 +17,7 @@ import {
 } from "@core/utils/payment/stripe";
 
 import Contact from "@models/Contact";
-import { StripePaymentData } from "@models/PaymentData";
+import { StripePaymentData } from "@models/ContactContribution";
 
 import NoPaymentMethod from "@api/errors/NoPaymentMethod";
 

--- a/src/core/providers/payment/index.ts
+++ b/src/core/providers/payment/index.ts
@@ -6,7 +6,9 @@ import { PaymentForm } from "@core/utils";
 import { CompletedPaymentFlow } from "@core/providers/payment-flow";
 
 import Contact from "@models/Contact";
-import PaymentData, { PaymentProviderData } from "@models/PaymentData";
+import ContactContribution, {
+  PaymentProviderData
+} from "@models/ContactContribution";
 import { ContributionInfo } from "@type/contribution-info";
 
 export interface UpdateContributionResult {
@@ -19,14 +21,14 @@ export abstract class PaymentProvider<T extends PaymentProviderData> {
   protected readonly contact: Contact;
   protected readonly method: PaymentMethod;
 
-  constructor(data: PaymentData) {
+  constructor(data: ContactContribution) {
     this.data = data.data as T;
     this.contact = data.contact;
     this.method = data.method as PaymentMethod;
   }
 
   protected async updateData() {
-    await getRepository(PaymentData).update(this.contact.id, {
+    await getRepository(ContactContribution).update(this.contact.id, {
       data: this.data
     });
   }

--- a/src/migrations/1713373413805-RenamePaymentDataToContactContribution.ts
+++ b/src/migrations/1713373413805-RenamePaymentDataToContactContribution.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RenamePaymentDataToContactContribution1713373413805
+  implements MigrationInterface
+{
+  name = "RenamePaymentDataToContactContribution1713373413805";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payment_data" RENAME TO "contact_contribution"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "contact_contribution" RENAME TO "payment_data"`
+    );
+  }
+}

--- a/src/models/Contact.ts
+++ b/src/models/Contact.ts
@@ -15,10 +15,10 @@ import {
 import { getActualAmount } from "@core/utils";
 import config from "@config";
 
+import type ContactContribution from "./ContactContribution";
 import type ContactRole from "./ContactRole";
 import type ContactProfile from "./ContactProfile";
 import Password from "./Password";
-import type PaymentData from "./PaymentData";
 
 import { ContributionInfo } from "@type/contribution-info";
 
@@ -74,10 +74,10 @@ export default class Contact {
   @OneToOne("ContactProfile", "contact")
   profile!: ContactProfile;
 
-  @OneToOne("PaymentData", "contact")
-  paymentData!: PaymentData;
+  @OneToOne("ContactContribution", "contact")
+  contribution!: ContactContribution;
 
-  contribution?: ContributionInfo;
+  contributionInfo?: ContributionInfo;
 
   get activeRoles(): RoleType[] {
     const ret = this.roles.filter((p) => p.isActive).map((p) => p.type);

--- a/src/models/ContactContribution.ts
+++ b/src/models/ContactContribution.ts
@@ -37,10 +37,10 @@ export type PaymentProviderData =
   | {};
 
 @Entity()
-export default class PaymentData {
+export default class ContactContribution {
   @PrimaryColumn()
   contactId!: string;
-  @OneToOne("Contact", "paymentData")
+  @OneToOne("Contact", "contribution")
   @JoinColumn()
   contact!: Contact;
 

--- a/src/tools/database/anonymisers/models.ts
+++ b/src/tools/database/anonymisers/models.ts
@@ -19,7 +19,7 @@ import Notice from "@models/Notice";
 import Option from "@models/Option";
 import PageSettings from "@models/PageSettings";
 import Payment from "@models/Payment";
-import PaymentData from "@models/PaymentData";
+import ContactContribution from "@models/ContactContribution";
 import Callout from "@models/Callout";
 import CalloutResponse from "@models/CalloutResponse";
 import CalloutResponseTag from "@models/CalloutResponseTag";
@@ -169,6 +169,21 @@ export const contactAnonymiser = createModelAnonymiser(Contact, {
   referralCode: uniqueCode
 });
 
+export const contactContributionAnonymiser = createModelAnonymiser(
+  ContactContribution,
+  {
+    contactId: () => uuidv4(),
+    data: createObjectMap<ContactContribution["data"]>({
+      customerId: randomId(12, "CU"),
+      mandateId: randomId(12, "MD"),
+      subscriptionId: randomId(12, "SB"),
+      source: () =>
+        chance.pickone(["Standing Order", "PayPal", "Cash in hand"]),
+      reference: () => chance.word()
+    })
+  }
+);
+
 export const contactProfileAnonymiser = createModelAnonymiser(ContactProfile, {
   contactId: () => uuidv4(),
   description: () => chance.sentence(),
@@ -221,17 +236,6 @@ export const noticesAnonymiser = createModelAnonymiser(Notice);
 export const optionsAnonymiser = createModelAnonymiser(Option);
 
 export const pageSettingsAnonymiser = createModelAnonymiser(PageSettings);
-
-export const paymentDataAnonymiser = createModelAnonymiser(PaymentData, {
-  contactId: () => uuidv4(),
-  data: createObjectMap<PaymentData["data"]>({
-    customerId: randomId(12, "CU"),
-    mandateId: randomId(12, "MD"),
-    subscriptionId: randomId(12, "SB"),
-    source: () => chance.pickone(["Standing Order", "PayPal", "Cash in hand"]),
-    reference: () => chance.word()
-  })
-});
 
 export const paymentsAnonymiser = createModelAnonymiser(Payment, {
   id: () => uuidv4(),

--- a/src/tools/database/export-demo.ts
+++ b/src/tools/database/export-demo.ts
@@ -9,7 +9,7 @@ import Contact from "@models/Contact";
 
 import {
   ModelAnonymiser,
-  paymentDataAnonymiser,
+  contactContributionAnonymiser,
   paymentsAnonymiser,
   contactAnonymiser,
   contactRoleAnonymiser,
@@ -34,7 +34,7 @@ const contactAnonymisers = [
   contactRoleAnonymiser,
   contactProfileAnonymiser,
   paymentsAnonymiser,
-  paymentDataAnonymiser
+  contactContributionAnonymiser
 ] as ModelAnonymiser[];
 
 const calloutsAnonymisers = [

--- a/src/tools/database/export.ts
+++ b/src/tools/database/export.ts
@@ -16,7 +16,7 @@ const anonymisers = [
   models.giftFlowAnonymiser,
   models.noticesAnonymiser,
   models.optionsAnonymiser,
-  models.paymentDataAnonymiser,
+  models.contactContributionAnonymiser,
   models.paymentsAnonymiser,
   models.pageSettingsAnonymiser,
   models.calloutsAnonymiser,

--- a/src/tools/gocardless/migrate-to-stripe.ts
+++ b/src/tools/gocardless/migrate-to-stripe.ts
@@ -15,7 +15,9 @@ import PaymentService from "@core/services/PaymentService";
 
 import Contact from "@models/Contact";
 import Payment from "@models/Payment";
-import PaymentData, { GCPaymentData } from "@models/PaymentData";
+import ContactContribution, {
+  GCPaymentData
+} from "@models/ContactContribution";
 
 import config from "@config";
 
@@ -80,9 +82,9 @@ runApp(async () => {
     )
     // Only select those which haven't cancelled and use GoCardless
     .innerJoinAndSelect(
-      "contact.paymentData",
-      "pd",
-      "pd.cancelledAt IS NULL AND pd.method = :method",
+      "contact.contribution",
+      "cc",
+      "cc.cancelledAt IS NULL AND cc.method = :method",
       { method: PaymentMethod.GoCardlessDirectDebit }
     )
     .getMany();
@@ -99,7 +101,7 @@ runApp(async () => {
   for (const contact of contacts) {
     const contactPayments = payments.filter((p) => p.contactId === contact.id);
 
-    const paymentData = contact.paymentData.data as GCPaymentData;
+    const paymentData = contact.contribution.data as GCPaymentData;
 
     const migrationRow = migrationData.find(
       (row) => row.old_customer_id === paymentData.customerId
@@ -144,7 +146,7 @@ runApp(async () => {
         // We do this directly rather than using updatePaymentMethod as it's not
         // meant for updating payment methods that are already associated with
         // the customer in Stripe
-        await getRepository(PaymentData).update(contact.id, {
+        await getRepository(ContactContribution).update(contact.id, {
           method: stripeTypeToPaymentMethod(migrationRow.type),
           data: {
             customerId: migrationRow.customer_id,

--- a/src/tools/stripe/resync.ts
+++ b/src/tools/stripe/resync.ts
@@ -8,7 +8,9 @@ import { runApp } from "@core/server";
 import stripe from "@core/lib/stripe";
 import ContactsService from "@core/services/ContactsService";
 
-import PaymentData, { StripePaymentData } from "@models/PaymentData";
+import ContactContribution, {
+  StripePaymentData
+} from "@models/ContactContribution";
 
 import {
   handleInvoicePaid,
@@ -32,7 +34,7 @@ async function* fetchInvoices(customerId: string) {
 }
 
 runApp(async () => {
-  const stripePaymentData = (await getRepository(PaymentData).find({
+  const stripePaymentData = (await getRepository(ContactContribution).find({
     where: {
       method: In([
         PaymentMethod.StripeBACS,
@@ -41,7 +43,7 @@ runApp(async () => {
       ])
     },
     relations: { contact: true }
-  })) as (PaymentData & { data: StripePaymentData })[];
+  })) as (ContactContribution & { data: StripePaymentData })[];
 
   for (const pd of stripePaymentData) {
     console.log(`# Checking ${pd.contact.email}`);
@@ -118,7 +120,7 @@ runApp(async () => {
     }
 
     if (isDangerMode) {
-      await getRepository(PaymentData).save(pd);
+      await getRepository(ContactContribution).save(pd);
     } else {
       console.log(pd.cancelledAt, pd.data);
     }

--- a/src/tools/test-users.ts
+++ b/src/tools/test-users.ts
@@ -16,7 +16,7 @@ import config from "@config";
 
 import Payment from "@models/Payment";
 import Contact from "@models/Contact";
-import PaymentData from "@models/PaymentData";
+import ContactContribution from "@models/ContactContribution";
 
 async function logContact(type: string, conditions: Brackets[]) {
   const qb = createQueryBuilder(Contact, "m")
@@ -82,19 +82,19 @@ async function getFilters() {
     .where("p.status = 'failed'", { status: PaymentStatus.Failed });
   const hasSubscription = createQueryBuilder()
     .subQuery()
-    .select("pd.contactId")
-    .from(PaymentData, "p")
-    .where("pd.subscriptionId IS NOT NULL");
+    .select("cc.contactId")
+    .from(ContactContribution, "cc")
+    .where("cc.subscriptionId IS NOT NULL");
   const hasCancelled = createQueryBuilder()
     .subQuery()
-    .select("pd.contactId")
-    .from(PaymentData, "md")
-    .where("md.cancelledAt IS NOT NULL");
+    .select("cc.contactId")
+    .from(ContactContribution, "cc")
+    .where("cc.cancelledAt IS NOT NULL");
   const isPayingFee = createQueryBuilder()
     .subQuery()
-    .select("md.contactId")
-    .from(PaymentData, "md")
-    .where("md.payFee = TRUE");
+    .select("cc.contactId")
+    .from(ContactContribution, "cc")
+    .where("cc.payFee = TRUE");
 
   return {
     isActive: new Brackets((qb) =>

--- a/src/webhooks/handlers/stripe.ts
+++ b/src/webhooks/handlers/stripe.ts
@@ -15,7 +15,9 @@ import ContactsService from "@core/services/ContactsService";
 import PaymentService from "@core/services/PaymentService";
 
 import Payment from "@models/Payment";
-import PaymentData, { StripePaymentData } from "@models/PaymentData";
+import ContactContribution, {
+  StripePaymentData
+} from "@models/ContactContribution";
 
 import config from "@config";
 
@@ -208,7 +210,7 @@ async function handlePaymentMethodDetached(
 
 async function getInvoiceData(
   invoice: Stripe.Invoice
-): Promise<PaymentData | undefined> {
+): Promise<ContactContribution | undefined> {
   if (invoice.customer) {
     const data = await PaymentService.getDataBy(
       "customerId",

--- a/src/webhooks/utils/gocardless.ts
+++ b/src/webhooks/utils/gocardless.ts
@@ -14,7 +14,7 @@ import { convertStatus } from "@core/utils/payment/gocardless";
 import ContactsService from "@core/services/ContactsService";
 import PaymentService from "@core/services/PaymentService";
 
-import { GCPaymentData } from "@models/PaymentData";
+import { GCPaymentData } from "@models/ContactContribution";
 import Payment from "@models/Payment";
 
 import config from "@config";


### PR DESCRIPTION
This PR is the first in a series aimed at refactoring the payment code. This first one is simple: give the table a better name. The table should always have been `ContactSomething` as it's dependent on a `Contact` object, and `Contribution` is a much clearer name than `PaymentData`