### PR TITLE
feat(contact-filters): add filter for if contact has answered the callout or not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^0.20.3",
+        "@beabee/beabee-common": "^0.20.5",
         "@captchafox/node": "^1.2.0",
         "@inquirer/prompts": "^3.3.0",
         "@sendgrid/mail": "^8.1.0",
@@ -851,9 +851,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.3.tgz",
-      "integrity": "sha512-3EDuDdWdVQvr9yZtIzKM37Gv5rwdyJK9q6XtgK0/JY5i7o/XRoCsqsfnEVMs52N1NQcnru8x+pwJnH4hXf1PbA==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.5.tgz",
+      "integrity": "sha512-cjZuh+n1QC5qOmcfkosGHjLA7FmgY7BigkKlFAm6g1LSc1Xosu28FwuuUv5qTkuwjUUtFDvK3GgZmR5b2FcSaA==",
       "dependencies": {
         "date-fns": "^3.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "jest --setupFiles dotenv/config"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^0.20.3",
+    "@beabee/beabee-common": "^0.20.5",
     "@captchafox/node": "^1.2.0",
     "@inquirer/prompts": "^3.3.0",
     "@sendgrid/mail": "^8.1.0",

--- a/src/api/transformers/BaseContactTransformer.ts
+++ b/src/api/transformers/BaseContactTransformer.ts
@@ -73,6 +73,8 @@ export abstract class BaseContactTransformer<
     for (const calloutId of calloutIds) {
       const callout = await getRepository(Callout).findOneBy({ id: calloutId });
       if (callout) {
+        filters[`callouts.${calloutId}.hasAnswered`] = { type: "boolean" };
+
         const calloutFilters = getCalloutFilters(callout.formSchema);
         for (const key in calloutFilters) {
           filters[`callouts.${calloutId}.responses.${key}`] =
@@ -81,7 +83,7 @@ export abstract class BaseContactTransformer<
       }
     }
 
-    return [filters, { "callouts.": calloutResponseFilterHandler }];
+    return [filters, { "callouts.": calloutsFilterHandler }];
   }
 }
 
@@ -151,25 +153,57 @@ const activePermission: FilterHandler = (qb, args) => {
   }
 };
 
-const calloutResponseFilterHandler: FilterHandler = (qb, args) => {
-  // Split out callouts.<id>.responses.<answerFields...>
-  const [, calloutId, , ...answerFields] = args.field.split(".");
+const calloutsFilterHandler: FilterHandler = (qb, args) => {
+  // Split out callouts.<id>.<filterName>[.<answerFields...>]
+  const [, calloutId, subField, ...answerFields] = args.field.split(".");
 
-  const subQb = createQueryBuilder()
-    .subQuery()
-    .select("item.contactId")
-    .from(CalloutResponse, "item");
+  let params;
 
-  const answerParams = individualAnswerFilterHandler(subQb, {
-    ...args,
-    field: answerFields.join(".")
-  });
+  switch (subField) {
+    /**
+     * Filter contacts by their answers to a callout, uses the same filters as
+     * callout responses endpoints
 
-  subQb
-    .andWhere(args.addParamSuffix("item.calloutId = :calloutId"))
-    .andWhere("item.contactId IS NOT NULL");
+     * Filter field: callout.<id>.responses.<answerFields>
+     */
+    case "responses": {
+      const subQb = createQueryBuilder()
+        .subQuery()
+        .select("item.contactId")
+        .from(CalloutResponse, "item");
 
-  qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+      params = individualAnswerFilterHandler(subQb, {
+        ...args,
+        field: answerFields.join(".")
+      });
 
-  return { calloutId, ...answerParams };
+      subQb
+        .andWhere(args.addParamSuffix("item.calloutId = :calloutId"))
+        .andWhere("item.contactId IS NOT NULL");
+
+      qb.where(`${args.fieldPrefix}id IN ${subQb.getQuery()}`);
+      break;
+    }
+
+    /**
+     * Filter contacts by whether they have answered a callout
+     *
+     * Filter field: callout.<id>.hasAnswered
+     */
+    case "hasAnswered": {
+      const subQb = createQueryBuilder()
+        .subQuery()
+        .select("item.contactId")
+        .from(CalloutResponse, "item")
+        .where(args.addParamSuffix(`item.calloutId = :calloutId`))
+        .andWhere("item.contactId IS NOT NULL");
+
+      const operator = args.value[0] ? "IN" : "NOT IN";
+
+      qb.where(`${args.fieldPrefix}id ${operator} ${subQb.getQuery()}`);
+      break;
+    }
+  }
+
+  return { calloutId, ...params };
 };

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -54,3 +54,14 @@ export function groupBy<T>(
   }
   return result;
 }
+
+export function prefixKeys(
+  prefix: string,
+  obj: Record<string, unknown>
+): Record<string, unknown> {
+  const newObj: any = {};
+  for (const key in obj) {
+    newObj[`${prefix}${key}`] = obj[key];
+  }
+  return newObj;
+}


### PR DESCRIPTION
Add a new filter to query for contacts that have answered a callout, rather than the more specific filters introduced in #392 which were about querying the specific answers to callouts