### PR TITLE
feat: add new draft payment status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.8",
       "license": "GPL-3.0",
       "dependencies": {
-        "@beabee/beabee-common": "^0.20.3",
+        "@beabee/beabee-common": "^0.20.7",
         "@captchafox/node": "^1.2.0",
         "@inquirer/prompts": "^3.3.0",
         "@sendgrid/mail": "^8.1.0",
@@ -851,9 +851,9 @@
       "dev": true
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.3.tgz",
-      "integrity": "sha512-3EDuDdWdVQvr9yZtIzKM37Gv5rwdyJK9q6XtgK0/JY5i7o/XRoCsqsfnEVMs52N1NQcnru8x+pwJnH4hXf1PbA==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.7.tgz",
+      "integrity": "sha512-zoupoEsxkb/PGzZ3CuGEhaobN3rJmz3U9VABtQc1+a8BwsPQDmOPK5XmQacvzTtiBd72nSngqsONDivIPrcLuQ==",
       "dependencies": {
         "date-fns": "^3.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "jest --setupFiles dotenv/config"
   },
   "dependencies": {
-    "@beabee/beabee-common": "^0.20.3",
+    "@beabee/beabee-common": "^0.20.7",
     "@captchafox/node": "^1.2.0",
     "@inquirer/prompts": "^3.3.0",
     "@sendgrid/mail": "^8.1.0",

--- a/src/core/utils/payment/gocardless.ts
+++ b/src/core/utils/payment/gocardless.ts
@@ -171,6 +171,8 @@ export async function hasPendingPayment(mandateId: string): Promise<boolean> {
 export function convertStatus(status: GCPaymentStatus): PaymentStatus {
   switch (status) {
     case GCPaymentStatus.PendingCustomerApproval:
+      return PaymentStatus.Draft;
+
     case GCPaymentStatus.PendingSubmission:
     case GCPaymentStatus.Submitted:
       return PaymentStatus.Pending;

--- a/src/core/utils/payment/stripe.ts
+++ b/src/core/utils/payment/stripe.ts
@@ -261,6 +261,8 @@ export async function manadateToSource(
 export function convertStatus(status: Stripe.Invoice.Status): PaymentStatus {
   switch (status) {
     case "draft":
+      return PaymentStatus.Draft;
+
     case "open":
       return PaymentStatus.Pending;
 

--- a/src/webhooks/handlers/stripe.ts
+++ b/src/webhooks/handlers/stripe.ts
@@ -143,7 +143,7 @@ export async function handleInvoiceUpdated(invoice: Stripe.Invoice) {
 
     payment.status = invoice.status
       ? convertStatus(invoice.status)
-      : PaymentStatus.Pending;
+      : PaymentStatus.Draft; // Not really possible for an updated invoice to have no status
     payment.description = invoice.description || "";
     payment.amount = invoice.total / 100;
     payment.chargeDate = new Date(invoice.created * 1000);


### PR DESCRIPTION
We currently give payments that have yet to be initiated and those that are being processed the same status of `pending`. On Stripe this means that draft invoices get categorised as pending, even though they will never be processed, and the same thing for GoCardless payments in state pending customer approval.

This PR introduces a new status, `draft`, to distinction between the two. Initially this is so we can filter payments on the frontend and not show users really old draft payments that will never be submitted.