### PR TITLE
fix: payment status updates being missed

### DIFF
--- a/src/webhooks/handlers/stripe.ts
+++ b/src/webhooks/handlers/stripe.ts
@@ -233,14 +233,14 @@ async function getContributionFromInvoice(
 async function findOrCreatePayment(
   invoice: Stripe.Invoice
 ): Promise<Payment | undefined> {
-  const contribution = await getContributionFromInvoice(invoice);
-  if (!contribution) {
-    return;
-  }
-
   const payment = await getRepository(Payment).findOneBy({ id: invoice.id });
   if (payment) {
     return payment;
+  }
+
+  const contribution = await getContributionFromInvoice(invoice);
+  if (!contribution) {
+    return;
   }
 
   const newPayment = new Payment();


### PR DESCRIPTION
If we already have the payment on file we should update it regardless of if we can find a corresponding contribution or not. This is a bit of an edge case, but can happen when a user creates a new customer but there is a retrospective update to a payment